### PR TITLE
Use model for Global section in Notification page

### DIFF
--- a/lib/schemas/schemas.dart
+++ b/lib/schemas/schemas.dart
@@ -14,4 +14,4 @@ const String schemaDesktopPeripheralsMouse =
 const String schemaPeripheralTouchpad =
     'org.gnome.desktop.peripherals.touchpad';
 const String schemaSound = 'org.gnome.desktop.sound';
-
+const String schemaNotifications = 'org.gnome.desktop.notifications';

--- a/lib/view/pages/menu_items.dart
+++ b/lib/view/pages/menu_items.dart
@@ -7,6 +7,7 @@ import 'package:settings/view/pages/appearance/appearance_page.dart';
 import 'package:settings/view/pages/keyboard_shortcuts_page/keyboard_shortcuts_page.dart';
 import 'package:settings/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart';
 import 'package:settings/view/pages/mouse_and_touchpad/mouse_and_touchpad_page.dart';
+import 'package:settings/view/pages/notifications_page.dart/notifications_model.dart';
 import 'package:settings/view/pages/notifications_page.dart/notifications_page.dart';
 import 'package:settings/view/pages/sound/sound_model.dart';
 import 'package:settings/view/pages/sound/sound_page.dart';
@@ -39,10 +40,13 @@ final menuItems = <MenuItem>[
     iconData: YaruIcons.desktop_panel_look,
     details: AppearancePage(),
   ),
-  const MenuItem(
+  MenuItem(
     name: 'Notifications',
     iconData: YaruIcons.notification,
-    details: NotificationsPage(),
+    details: ChangeNotifierProvider<NotificationsModel>(
+      create: (_) => NotificationsModel(),
+      child: const NotificationsPage(),
+    ),
   ),
   const MenuItem(
     name: 'Search',

--- a/lib/view/pages/notifications_page.dart/global_notifications_section.dart
+++ b/lib/view/pages/notifications_page.dart/global_notifications_section.dart
@@ -9,20 +9,20 @@ class GlobalNotificationsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final _model = Provider.of<NotificationsModel>(context);
+    final model = Provider.of<NotificationsModel>(context);
 
     return SettingsSection(
       headline: 'Global',
       children: [
         SwitchSettingsRow(
           actionLabel: 'Do Not Disturb',
-          value: _model.getDoNotDisturb,
-          onChanged: (value) => _model.setDoNotDisturb(value),
+          value: model.getDoNotDisturb,
+          onChanged: (value) => model.setDoNotDisturb(value),
         ),
         SwitchSettingsRow(
           actionLabel: 'Show Notifications On Lock Screen',
-          value: _model.getShowOnLockScreen,
-          onChanged: (value) => _model.setShowOnLockScreen(value),
+          value: model.getShowOnLockScreen,
+          onChanged: (value) => model.setShowOnLockScreen(value),
         ),
       ],
     );

--- a/lib/view/pages/notifications_page.dart/global_notifications_section.dart
+++ b/lib/view/pages/notifications_page.dart/global_notifications_section.dart
@@ -16,12 +16,12 @@ class GlobalNotificationsSection extends StatelessWidget {
       children: [
         SwitchSettingsRow(
           actionLabel: 'Do Not Disturb',
-          value: model.getDoNotDisturb,
+          value: model.doNotDisturb,
           onChanged: (value) => model.setDoNotDisturb(value),
         ),
         SwitchSettingsRow(
           actionLabel: 'Show Notifications On Lock Screen',
-          value: model.getShowOnLockScreen,
+          value: model.showOnLockScreen,
           onChanged: (value) => model.setShowOnLockScreen(value),
         ),
       ],

--- a/lib/view/pages/notifications_page.dart/global_notifications_section.dart
+++ b/lib/view/pages/notifications_page.dart/global_notifications_section.dart
@@ -1,29 +1,29 @@
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+import 'package:settings/view/pages/notifications_page.dart/notifications_model.dart';
 import 'package:settings/view/widgets/settings_section.dart';
-import 'package:settings/view/widgets/single_gsetting_row.dart';
+import 'package:settings/view/widgets/switch_settings_row.dart';
 
 class GlobalNotificationsSection extends StatelessWidget {
   const GlobalNotificationsSection({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    const _schemaId = 'org.gnome.desktop.notifications';
+    final _model = Provider.of<NotificationsModel>(context);
 
-    return const SettingsSection(
-      schemaId: _schemaId,
+    return SettingsSection(
       headline: 'Global',
       children: [
-        SingleGsettingRow(
-          actionLabel: 'Do not disturb',
-          settingsKey: 'show-banners',
-          schemaId: _schemaId,
-          invertedValue: true,
+        SwitchSettingsRow(
+          actionLabel: 'Do Not Disturb',
+          value: _model.getDoNotDisturb,
+          onChanged: (value) => _model.setDoNotDisturb(value),
         ),
-        SingleGsettingRow(
-          actionLabel: 'Show notifications on lockscreen',
-          settingsKey: 'show-in-lock-screen',
-          schemaId: _schemaId,
-        )
+        SwitchSettingsRow(
+          actionLabel: 'Show Notifications On Lock Screen',
+          value: _model.getShowOnLockScreen,
+          onChanged: (value) => _model.setShowOnLockScreen(value),
+        ),
       ],
     );
   }

--- a/lib/view/pages/notifications_page.dart/notifications_model.dart
+++ b/lib/view/pages/notifications_page.dart/notifications_model.dart
@@ -19,7 +19,7 @@ class NotificationsModel extends ChangeNotifier {
 
   // Global section
 
-  bool? get getDoNotDisturb {
+  bool? get doNotDisturb {
     if (_notificationSettings != null) {
       return !_notificationSettings!.boolValue(_showBannersKey);
     }
@@ -30,7 +30,7 @@ class NotificationsModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool? get getShowOnLockScreen =>
+  bool? get showOnLockScreen =>
       _notificationSettings?.boolValue(_showInLockScreenKey);
 
   void setShowOnLockScreen(bool value) {

--- a/lib/view/pages/notifications_page.dart/notifications_model.dart
+++ b/lib/view/pages/notifications_page.dart/notifications_model.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/foundation.dart';
+import 'package:gsettings/gsettings.dart';
+import 'package:settings/schemas/schemas.dart';
+
+class NotificationsModel extends ChangeNotifier {
+  static const _showBannersKey = 'show-banners';
+  static const _showInLockScreenKey = 'show-in-lock-screen';
+
+  final _notificationSettings =
+      GSettingsSchema.lookup(schemaNotifications) != null
+          ? GSettings(schemaId: schemaNotifications)
+          : null;
+
+  @override
+  void dispose() {
+    _notificationSettings?.dispose();
+    super.dispose();
+  }
+
+  // Global section
+
+  bool? get getDoNotDisturb {
+    if (_notificationSettings != null) {
+      return !_notificationSettings!.boolValue(_showBannersKey);
+    }
+  }
+
+  void setDoNotDisturb(bool value) {
+    _notificationSettings?.setValue(_showBannersKey, !value);
+    notifyListeners();
+  }
+
+  bool? get getShowOnLockScreen =>
+      _notificationSettings?.boolValue(_showInLockScreenKey);
+
+  void setShowOnLockScreen(bool value) {
+    _notificationSettings?.setValue(_showInLockScreenKey, value);
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
For now just the Global section. I've noticed the current implementation of the App section actually does not work at the moment. :open_mouth: 