### PR TITLE
Keyboardshort page improvements

### DIFF
--- a/lib/schemas/schemas.dart
+++ b/lib/schemas/schemas.dart
@@ -8,6 +8,7 @@ const String schemaPeripheralsKeyboard =
     'org.gnome.desktop.peripherals.keyboard';
 const String schemaWmPreferences = 'org.gnome.desktop.wm.preferences';
 const schemaWmKeybindings = 'org.gnome.desktop.wm.keybindings';
+const schemaGnomeShellKeybinding = 'org.gnome.shell.keybindings';
 const String schemaPeripheralsMouse =
     'org.gnome.settings-daemon.peripherals.mouse';
 const String schemaDesktopPeripheralsMouse =

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
@@ -41,7 +41,6 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
         final oldShortcut = model.shortcut(widget.shortcutId);
         // TODO: grab the keyboard from gnome-shell
         showDialog<List<String>>(
-          barrierDismissible: false,
           context: context,
           builder: (_) => StatefulBuilder(builder: (context, setState) {
             return RawKeyboardListener(

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
@@ -37,89 +37,112 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
         ),
       ),
       borderRadius: BorderRadius.circular(4.0),
-      onTap: () => showDialog(
-        barrierDismissible: false,
-        context: context,
-        builder: (_) => StatefulBuilder(builder: (context, setState) {
-          return RawKeyboardListener(
-            focusNode: FocusNode(),
-            autofocus: true,
-            onKey: (event) {
-              if (event.logicalKey == LogicalKeyboardKey.escape) {
-                keys.clear();
-                return;
-              }
-              if (!keys.contains(event.logicalKey) && keys.length < 4) {
-                setState(() => keys.add(event.logicalKey));
-              }
-            },
-            child: AlertDialog(
-              title: Text(
-                'Start typing... ',
-                style: Theme.of(context).textTheme.subtitle1,
-              ),
-              content: SizedBox(
-                height: 100,
-                width: 300,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: keys
-                          .map(
-                            (key) => Card(
-                              child: Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Text(key.keyLabel),
-                              ),
-                            ),
-                          )
-                          .toList(),
-                    ),
-                    Text(
-                      keys.isEmpty ? '' : 'Press cancel to cancel',
-                      style: Theme.of(context).textTheme.subtitle2,
-                    ),
-                  ],
+      onTap: () {
+        final oldShortcut = model.shortcut(widget.shortcutId);
+
+        showDialog(
+          barrierDismissible: false,
+          context: context,
+          builder: (_) => StatefulBuilder(builder: (context, setState) {
+            return RawKeyboardListener(
+              focusNode: FocusNode(),
+              autofocus: true,
+              onKey: (event) {
+                if (event.logicalKey == LogicalKeyboardKey.escape) {
+                  keys.clear();
+                  model.setShortcut(widget.shortcutId, oldShortcut);
+                  Navigator.of(context).pop();
+                  return;
+                }
+                if (!keys.contains(event.logicalKey) && keys.length < 4) {
+                  model.setShortcut(widget.shortcutId, []);
+                  setState(() => keys.add(event.logicalKey));
+                }
+              },
+              child: AlertDialog(
+                title: Text(
+                  'Start typing... ',
+                  style: Theme.of(context).textTheme.subtitle1,
                 ),
-              ),
-              actions: [
-                OutlinedButton(
+                content: SizedBox(
+                  height: 100,
+                  width: 300,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: keys
+                            .map(
+                              (key) => Card(
+                                child: Padding(
+                                  padding: const EdgeInsets.all(8.0),
+                                  child: Text(key.keyLabel),
+                                ),
+                              ),
+                            )
+                            .toList(),
+                      ),
+                      Text(
+                        keys.isEmpty ? '' : 'Press cancel to cancel',
+                        style: Theme.of(context).textTheme.subtitle2,
+                      ),
+                    ],
+                  ),
+                ),
+                actions: [
+                  OutlinedButton(
+                      onPressed: () {
+                        keys.clear();
+                        model.setShortcut(widget.shortcutId, oldShortcut);
+                        Navigator.of(context).pop();
+                      },
+                      child: const Text('Cancel')),
+                  ElevatedButton(
+                    child: const Text('Confirm'),
                     onPressed: () {
+                      // TODO: How to prevent gnome shell
+                      // from executing key combos while typing?
+                      // As a work-around we store the old shortcut
+                      // unset the current shortcut temporarily
+                      // then set the new shortcut
+
+                      final keyBuffer = StringBuffer();
+                      for (var key in keys) {
+                        var keyLabel = key.keyLabel;
+                        if (keyLabel == 'Alt Left' ||
+                            keyLabel == 'Control Left' ||
+                            keyLabel == 'Super Left' ||
+                            keyLabel == 'Shift Left') {
+                          keyLabel =
+                              '<' + keyLabel.replaceAll(' Left', '') + '>';
+                        } else if (keyLabel == 'Alt Right' ||
+                            keyLabel == 'Control Right' ||
+                            keyLabel == 'Super Right' ||
+                            keyLabel == 'Shift Right') {
+                          keyLabel =
+                              '<' + keyLabel.replaceAll(' Right', '') + '>';
+                        }
+                        keyBuffer.write(keyLabel);
+                      }
+                      setState(() => model.setShortcut(
+                            widget.shortcutId,
+                            [keyBuffer.toString()],
+                          ));
                       keys.clear();
                       Navigator.of(context).pop();
                     },
-                    child: const Text('Cancel')),
-                ElevatedButton(
-                  child: const Text('Confirm'),
-                  onPressed: () {
-                    // TODO: How to prevent gnome shell
-                    // from executing key combos while typing?
-
-                    final keyBuffer = StringBuffer();
-                    for (var element in keys) {
-                      var keyLabel = element.keyLabel;
-                      if (keyLabel == 'Alt Left' ||
-                          keyLabel == 'Control Left' ||
-                          keyLabel == 'Shift Left') {
-                        keyLabel = '<' + keyLabel.replaceAll(' Left', '') + '>';
-                      }
-                      keyBuffer.write(keyLabel);
-                    }
-                    setState(() => model.setShortcut(
-                          widget.shortcutId,
-                          [keyBuffer.toString()],
-                        ));
-                    keys.clear();
-                    Navigator.of(context).pop();
-                  },
-                )
-              ],
-            ),
-          );
-        }),
-      ),
+                  )
+                ],
+              ),
+            );
+          }),
+        ).then((value) {
+          if (model.shortcut(widget.shortcutId).isEmpty) {
+            model.setShortcut(widget.shortcutId, oldShortcut);
+          }
+        });
+      },
     );
   }
 }

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
@@ -48,75 +48,15 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
               focusNode: FocusNode(),
               autofocus: true,
               onKey: (event) {
-                if (event.logicalKey == LogicalKeyboardKey.escape) {
-                  Navigator.of(context).pop();
-                }
-                if (!keys.contains(event.logicalKey) && keys.length < 4) {
+                if (event.logicalKey != LogicalKeyboardKey.escape &&
+                    !keys.contains(event.logicalKey) &&
+                    keys.length < 4) {
                   setState(() => keys.add(event.logicalKey));
                 }
               },
-              child: AlertDialog(
-                title: Text(
-                  'Start typing... ',
-                  style: Theme.of(context).textTheme.subtitle1,
-                ),
-                content: SizedBox(
-                  height: 100,
-                  width: 300,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: keys
-                            .map(
-                              (key) => Card(
-                                child: Padding(
-                                  padding: const EdgeInsets.all(8.0),
-                                  child: Text(key.keyLabel),
-                                ),
-                              ),
-                            )
-                            .toList(),
-                      ),
-                      Text(
-                        keys.isEmpty ? '' : 'Press cancel to cancel',
-                        style: Theme.of(context).textTheme.subtitle2,
-                      ),
-                    ],
-                  ),
-                ),
-                actions: [
-                  OutlinedButton(
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                      },
-                      child: const Text('Cancel')),
-                  ElevatedButton(
-                    child: const Text('Confirm'),
-                    onPressed: () {
-                      final keyBuffer = StringBuffer();
-                      for (var key in keys) {
-                        var keyLabel = key.keyLabel;
-                        if (keyLabel == 'Alt Left' ||
-                            keyLabel == 'Control Left' ||
-                            keyLabel == 'Super Left' ||
-                            keyLabel == 'Shift Left') {
-                          keyLabel =
-                              '<' + keyLabel.replaceAll(' Left', '') + '>';
-                        } else if (keyLabel == 'Alt Right' ||
-                            keyLabel == 'Control Right' ||
-                            keyLabel == 'Super Right' ||
-                            keyLabel == 'Shift Right') {
-                          keyLabel =
-                              '<' + keyLabel.replaceAll(' Right', '') + '>';
-                        }
-                        keyBuffer.write(keyLabel);
-                      }
-                      Navigator.of(context).pop([keyBuffer.toString()]);
-                    },
-                  )
-                ],
+              child: KeyboardShortcutDialog(
+                keys: keys,
+                oldShortcut: oldShortcut,
               ),
             );
           }),
@@ -125,6 +65,82 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
           model.setShortcut(widget.shortcutId, shortcut ?? oldShortcut);
         });
       },
+    );
+  }
+}
+
+class KeyboardShortcutDialog extends StatelessWidget {
+  const KeyboardShortcutDialog({
+    Key? key,
+    required this.keys,
+    required this.oldShortcut,
+  }) : super(key: key);
+
+  final List<LogicalKeyboardKey> keys;
+  final List<String> oldShortcut;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        'Start typing... ',
+        style: Theme.of(context).textTheme.subtitle1,
+      ),
+      content: SizedBox(
+        height: 100,
+        width: 300,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: keys
+                  .map(
+                    (key) => Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Text(key.keyLabel),
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+            Text(
+              keys.isEmpty ? '' : 'Press cancel to cancel',
+              style: Theme.of(context).textTheme.subtitle2,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        OutlinedButton(
+            onPressed: () {
+              Navigator.of(context).pop(oldShortcut);
+            },
+            child: const Text('Cancel')),
+        ElevatedButton(
+          child: const Text('Confirm'),
+          onPressed: () {
+            final keyBuffer = StringBuffer();
+            for (var key in keys) {
+              var keyLabel = key.keyLabel;
+              if (keyLabel == 'Alt Left' ||
+                  keyLabel == 'Control Left' ||
+                  keyLabel == 'Meta Left' ||
+                  keyLabel == 'Shift Left') {
+                keyLabel = '<' + keyLabel.replaceAll(' Left', '') + '>';
+              } else if (keyLabel == 'Alt Right' ||
+                  keyLabel == 'Control Right' ||
+                  keyLabel == 'Meta Right' ||
+                  keyLabel == 'Shift Right') {
+                keyLabel = '<' + keyLabel.replaceAll(' Right', '') + '>';
+              }
+              keyBuffer.write(keyLabel);
+            }
+            Navigator.of(context).pop([keyBuffer.toString()]);
+          },
+        )
+      ],
     );
   }
 }

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
@@ -40,7 +40,7 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
       onTap: () {
         final oldShortcut = model.shortcut(widget.shortcutId);
 
-        showDialog(
+        showDialog<List<String>>(
           barrierDismissible: false,
           context: context,
           builder: (_) => StatefulBuilder(builder: (context, setState) {
@@ -49,12 +49,14 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
               autofocus: true,
               onKey: (event) {
                 if (event.logicalKey == LogicalKeyboardKey.escape) {
-                  keys.clear();
-                  model.setShortcut(widget.shortcutId, oldShortcut);
                   Navigator.of(context).pop();
-                  return;
                 }
                 if (!keys.contains(event.logicalKey) && keys.length < 4) {
+                  // Unsetting the current shortcut is only needed to not
+                  // Trigger it in the moment you want to set it
+                  // This does not really make sense
+                  // Because we can't predict what other shortcut
+                  // Is being triggered
                   model.setShortcut(widget.shortcutId, []);
                   setState(() => keys.add(event.logicalKey));
                 }
@@ -93,8 +95,6 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
                 actions: [
                   OutlinedButton(
                       onPressed: () {
-                        keys.clear();
-                        model.setShortcut(widget.shortcutId, oldShortcut);
                         Navigator.of(context).pop();
                       },
                       child: const Text('Cancel')),
@@ -125,22 +125,20 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
                         }
                         keyBuffer.write(keyLabel);
                       }
-                      setState(() => model.setShortcut(
-                            widget.shortcutId,
-                            [keyBuffer.toString()],
-                          ));
-                      keys.clear();
-                      Navigator.of(context).pop();
+                      model.setShortcut(
+                        widget.shortcutId,
+                        [keyBuffer.toString()],
+                      );
+                      Navigator.of(context).pop(keyBuffer.toString());
                     },
                   )
                 ],
               ),
             );
           }),
-        ).then((value) {
-          if (model.shortcut(widget.shortcutId).isEmpty) {
-            model.setShortcut(widget.shortcutId, oldShortcut);
-          }
+        ).then((shortcut) {
+          keys.clear();
+          model.setShortcut(widget.shortcutId, shortcut ?? oldShortcut);
         });
       },
     );

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart
@@ -39,7 +39,7 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
       borderRadius: BorderRadius.circular(4.0),
       onTap: () {
         final oldShortcut = model.shortcut(widget.shortcutId);
-
+        // TODO: grab the keyboard from gnome-shell
         showDialog<List<String>>(
           barrierDismissible: false,
           context: context,
@@ -52,12 +52,6 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
                   Navigator.of(context).pop();
                 }
                 if (!keys.contains(event.logicalKey) && keys.length < 4) {
-                  // Unsetting the current shortcut is only needed to not
-                  // Trigger it in the moment you want to set it
-                  // This does not really make sense
-                  // Because we can't predict what other shortcut
-                  // Is being triggered
-                  model.setShortcut(widget.shortcutId, []);
                   setState(() => keys.add(event.logicalKey));
                 }
               },
@@ -101,12 +95,6 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
                   ElevatedButton(
                     child: const Text('Confirm'),
                     onPressed: () {
-                      // TODO: How to prevent gnome shell
-                      // from executing key combos while typing?
-                      // As a work-around we store the old shortcut
-                      // unset the current shortcut temporarily
-                      // then set the new shortcut
-
                       final keyBuffer = StringBuffer();
                       for (var key in keys) {
                         var keyLabel = key.keyLabel;
@@ -125,11 +113,7 @@ class _KeyboardShortcutRowState extends State<KeyboardShortcutRow> {
                         }
                         keyBuffer.write(keyLabel);
                       }
-                      model.setShortcut(
-                        widget.shortcutId,
-                        [keyBuffer.toString()],
-                      );
-                      Navigator.of(context).pop(keyBuffer.toString());
+                      Navigator.of(context).pop([keyBuffer.toString()]);
                     },
                   )
                 ],

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcuts_model.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcuts_model.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:gsettings/gsettings.dart';
-import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
 class KeyboardShortcutsModel extends ChangeNotifier {
-  KeyboardShortcutsModel(SettingsService service)
-      : _shortcutSettings = service.lookup(schemaWmKeybindings);
+  final String schemaId;
+
+  KeyboardShortcutsModel(SettingsService service, {required this.schemaId})
+      : _shortcutSettings = service.lookup(schemaId);
 
   final GSettings? _shortcutSettings;
 

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcuts_page.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcuts_page.dart
@@ -1,25 +1,33 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/keyboard_shortcuts/keyboard_shortcuts_model.dart';
 import 'package:settings/view/pages/keyboard_shortcuts/navigation_shortcuts_section.dart';
+import 'package:settings/view/pages/keyboard_shortcuts/system_shortcuts_section.dart';
 
 class KeyboardShortcutsPage extends StatelessWidget {
   const KeyboardShortcutsPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
-    return ChangeNotifierProvider(
-      create: (_) => KeyboardShortcutsModel(service),
-      child: const KeyboardShortcutsPage(),
-    );
+    return const KeyboardShortcutsPage();
   }
 
   @override
   Widget build(BuildContext context) {
+    final service = Provider.of<SettingsService>(context, listen: false);
     return Column(
-      children: const [
-        NavigationShortcutsSection(),
+      children: [
+        ChangeNotifierProvider(
+          create: (_) =>
+              KeyboardShortcutsModel(service, schemaId: schemaWmKeybindings),
+          child: const NavigationShortcutsSection(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => KeyboardShortcutsModel(service,
+              schemaId: schemaGnomeShellKeybinding),
+          child: const SystemShortcutsSection(),
+        ),
       ],
     );
   }

--- a/lib/view/pages/keyboard_shortcuts/system_shortcuts_section.dart
+++ b/lib/view/pages/keyboard_shortcuts/system_shortcuts_section.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:settings/view/pages/keyboard_shortcuts/keyboard_shortcut_row.dart';
+import 'package:settings/view/widgets/settings_section.dart';
+
+class SystemShortcutsSection extends StatelessWidget {
+  const SystemShortcutsSection({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const SettingsSection(
+      headline: 'System',
+      children: [
+        KeyboardShortcutRow(
+          label: 'Toggle Apps Grid',
+          shortcutId: 'toggle-application-view',
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- unset shortcut just a moment before setting it to preventing to toggle the current action while setting up a new one, this needs a smarter implementation in the future, for example grabbing the keyboard or unsetting all keybindings in this moment
- slightly improved keyboard_shortcut_model to take a schema as an argument to have multiple model instances
- adding a system section with one row as a proof of concept