### PR TITLE
Fix info services and management

### DIFF
--- a/lib/services/hostname_service.dart
+++ b/lib/services/hostname_service.dart
@@ -23,7 +23,7 @@ class HostnameService {
 
   Future<void> init() async {
     await _initProperties();
-    _propertyListener = _object.propertiesChanged.listen(_updateProperties);
+    _propertyListener ??= _object.propertiesChanged.listen(_updateProperties);
   }
 
   Future<void> dispose() async {
@@ -31,6 +31,7 @@ class HostnameService {
     await _staticHostnameController.close();
     await _propertyListener?.cancel();
     await _object.client.close();
+    _propertyListener = null;
   }
 
   late final DBusRemoteObject _object;
@@ -42,11 +43,11 @@ class HostnameService {
 
   String get hostname => _prettyHostname.orIfEmpty(_hostname);
   Stream<String> get hostnameChanged => _hostnameController.stream;
-  final _hostnameController = StreamController<String>();
+  final _hostnameController = StreamController<String>.broadcast();
 
   String get staticHostname => _staticHostname.orIfEmpty(_hostname.toStatic());
   Stream<String> get staticHostnameChanged => _staticHostnameController.stream;
-  final _staticHostnameController = StreamController<String>();
+  final _staticHostnameController = StreamController<String>.broadcast();
 
   Future<void> setHostname(String hostname) async {
     await _object.setHostname('SetPrettyHostname', hostname);

--- a/lib/services/hostname_service.dart
+++ b/lib/services/hostname_service.dart
@@ -43,11 +43,11 @@ class HostnameService {
 
   String get hostname => _prettyHostname.orIfEmpty(_hostname);
   Stream<String> get hostnameChanged => _hostnameController.stream;
-  final _hostnameController = StreamController<String>.broadcast();
+  final _hostnameController = StreamController<String>();
 
   String get staticHostname => _staticHostname.orIfEmpty(_hostname.toStatic());
   Stream<String> get staticHostnameChanged => _staticHostnameController.stream;
-  final _staticHostnameController = StreamController<String>.broadcast();
+  final _staticHostnameController = StreamController<String>();
 
   Future<void> setHostname(String hostname) async {
     await _object.setHostname('SetPrettyHostname', hostname);

--- a/lib/view/pages/info/info_model.dart
+++ b/lib/view/pages/info/info_model.dart
@@ -65,11 +65,4 @@ class InfoModel extends SafeChangeNotifier {
 
   String get gnomeVersion => _gnomeInfo.version;
   String get windowServer => Platform.environment['XDG_SESSION_TYPE'] ?? '';
-
-  @override
-  void dispose() {
-    _hostnameService.dispose();
-    _uDisksClient.close();
-    super.dispose();
-  }
 }


### PR DESCRIPTION
The view model does lazy initialization of the relevant services,
but is _not_ in charge of disposing them. The same services are used
whenever re-entering the view, and could be used by other view models
too, so don't dispose services when navigating away and the model gets
disposed.

Fixes: #108