### PR TITLE
power page styling

### DIFF
--- a/lib/view/pages/power/battery_section.dart
+++ b/lib/view/pages/power/battery_section.dart
@@ -4,6 +4,7 @@ import 'package:settings/view/pages/power/battery_model.dart';
 import 'package:settings/view/pages/power/battery_widgets.dart';
 import 'package:settings/view/widgets/settings_section.dart';
 import 'package:upower/upower.dart';
+import 'package:yaru/yaru.dart' as yaru;
 
 class BatterySection extends StatefulWidget {
   const BatterySection({Key? key}) : super(key: key);
@@ -36,7 +37,13 @@ class _BatterySectionState extends State<BatterySection> {
       children: <Widget>[
         Padding(
           padding: const EdgeInsets.all(8.0),
-          child: LinearProgressIndicator(value: model.percentage / 100.0),
+          child: LinearProgressIndicator(
+              value: model.percentage / 100.0,
+              color: model.percentage > 80.0
+                  ? yaru.Colors.green
+                  : model.percentage < 30.0
+                      ? Colors.red
+                      : Colors.amber),
         ),
         Padding(
           padding: const EdgeInsets.all(8.0),

--- a/lib/view/pages/power/power_profile_section.dart
+++ b/lib/view/pages/power/power_profile_section.dart
@@ -32,6 +32,7 @@ class _PowerProfileSectionState extends State<PowerProfileSection> {
       headline: 'Power Mode',
       children: <Widget>[
         RadioListTile<PowerProfile>(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
           title: const Text('Performance'),
           subtitle: const Text('High performance and power usage.'),
           value: PowerProfile.performance,
@@ -39,6 +40,7 @@ class _PowerProfileSectionState extends State<PowerProfileSection> {
           onChanged: model.setProfile,
         ),
         RadioListTile<PowerProfile>(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
           title: const Text('Balanced Power'),
           subtitle: const Text('Standard performance and power usage.'),
           value: PowerProfile.balanced,
@@ -46,6 +48,7 @@ class _PowerProfileSectionState extends State<PowerProfileSection> {
           onChanged: model.setProfile,
         ),
         RadioListTile<PowerProfile>(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
           title: const Text('Power Saver'),
           subtitle: const Text('Reduced performance and power usage.'),
           value: PowerProfile.powerSaver,

--- a/lib/view/pages/power/power_settings_dialogs.dart
+++ b/lib/view/pages/power/power_settings_dialogs.dart
@@ -21,23 +21,30 @@ class AutomaticSuspendDialog extends StatelessWidget {
     final model = context.watch<SuspendModel>();
     return SimpleDialog(
       title: const Center(child: Text('Automatic Suspend')),
-      contentPadding: const EdgeInsets.symmetric(vertical: 8.0),
+      contentPadding: const EdgeInsets.symmetric(vertical: 20.0),
       children: <Widget>[
-        SuspendDelaySettingsRow(
-          actionLabel: 'On Battery Power',
-          suspend: model.suspendOnBattery,
-          onSuspendChanged: model.setSuspendOnBattery,
-          delay: model.suspendOnBatteryDelay,
-          onDelayChanged: model.setSuspendOnBatteryDelay,
+        Padding(
+          padding: const EdgeInsets.only(left: 20, right: 20),
+          child: SuspendDelaySettingsRow(
+            actionLabel: 'On Battery Power',
+            suspend: model.suspendOnBattery,
+            onSuspendChanged: model.setSuspendOnBattery,
+            delay: model.suspendOnBatteryDelay,
+            onDelayChanged: model.setSuspendOnBatteryDelay,
+          ),
         ),
         const SizedBox(height: 16.0),
-        SuspendDelaySettingsRow(
-          actionLabel: 'When Plugged In',
-          suspend: model.suspendWhenPluggedIn,
-          onSuspendChanged: model.setSuspendWhenPluggedIn,
-          delay: model.suspendWhenPluggedInDelay,
-          onDelayChanged: model.setSuspendWhenPluggedInDelay,
+        Padding(
+          padding: const EdgeInsets.only(left: 20, right: 20),
+          child: SuspendDelaySettingsRow(
+            actionLabel: 'When Plugged In',
+            suspend: model.suspendWhenPluggedIn,
+            onSuspendChanged: model.setSuspendWhenPluggedIn,
+            delay: model.suspendWhenPluggedInDelay,
+            onDelayChanged: model.setSuspendWhenPluggedInDelay,
+          ),
         ),
+        const SizedBox(height: 16.0),
       ],
     );
   }

--- a/lib/view/pages/power/power_settings_widgets.dart
+++ b/lib/view/pages/power/power_settings_widgets.dart
@@ -54,29 +54,32 @@ class SuspendDelaySettingsRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        SwitchSettingsRow(
-          actionLabel: actionLabel,
-          value: suspend,
-          onChanged: onSuspendChanged,
-        ),
-        Row(
-          children: <Widget>[
-            const Spacer(),
-            const Text('Delay'),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: DurationDropdownButton(
-                value: delay,
-                values: SuspendDelay.values,
-                onChanged: onDelayChanged,
+    return SizedBox(
+      width: 300,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          SwitchSettingsRow(
+            actionLabel: actionLabel,
+            value: suspend,
+            onChanged: onSuspendChanged,
+          ),
+          Row(
+            children: <Widget>[
+              const Spacer(),
+              const Text('Delay'),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: DurationDropdownButton(
+                  value: delay,
+                  values: SuspendDelay.values,
+                  onChanged: onDelayChanged,
+                ),
               ),
-            ),
-          ],
-        ),
-      ],
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/pages/power/suspend_section.dart
+++ b/lib/view/pages/power/suspend_section.dart
@@ -44,7 +44,7 @@ class _SuspendSectionState extends State<SuspendSection> {
           ),
         ),
         SwitchSettingsRow(
-          actionLabel: 'Show Battery Percengate',
+          actionLabel: 'Show Battery Percentage',
           value: model.showBatteryPercentage,
           onChanged: model.setShowBatteryPercentage,
         ),


### PR DESCRIPTION
- green bar for battery charge above 80%, red for below 30
- better spacing and max width for the suspend dialog
- fix typo
- round radio list tiles

![grafik](https://user-images.githubusercontent.com/15329494/135735947-208f0e22-59e8-4639-bdfe-e63ce5fe8a1a.png)

![grafik](https://user-images.githubusercontent.com/15329494/135735952-2af9bd7a-3486-46d7-85ae-6166adef7466.png)

![round](https://user-images.githubusercontent.com/15329494/135736028-3da03f21-8084-43ff-bc5a-08cb34a46600.gif)

![grafik](https://user-images.githubusercontent.com/15329494/135756644-187bfff9-0a3a-4d09-aff6-7f28db5b62dc.png)

