### PR TITLE
Fix search

### DIFF
--- a/lib/view/widgets/landscape_layout.dart
+++ b/lib/view/widgets/landscape_layout.dart
@@ -38,15 +38,9 @@ class _LandscapeLayoutState extends State<LandscapeLayout> {
   }
 
   void onTap(int index) {
-    _searchActive = false;
     if (_filteredItems.isNotEmpty) {
-      for (var pageItem in widget.pages) {
-        if (pageItem.title == _filteredItems[index].title) {
-          index = widget.pages.indexOf(pageItem);
-          break;
-        }
-      }
-      _filteredItems.clear();
+      index = widget.pages.indexOf(widget.pages.firstWhere(
+          (pageItem) => pageItem.title == _filteredItems[index].title));
     }
 
     widget.onSelected(index);
@@ -140,10 +134,7 @@ class _LandscapeLayoutState extends State<LandscapeLayout> {
               _filteredItems.clear();
             }),
         onTap: () {
-          setState(() {
-            _searchActive = true;
-            _searchController.clear();
-          });
+          setState(() => _searchActive = true);
         });
   }
 }

--- a/lib/view/widgets/landscape_layout.dart
+++ b/lib/view/widgets/landscape_layout.dart
@@ -134,7 +134,13 @@ class _LandscapeLayoutState extends State<LandscapeLayout> {
               _filteredItems.clear();
             }),
         onTap: () {
-          setState(() => _searchActive = true);
+          setState(() {
+            _searchActive = !_searchActive;
+            if (!_searchActive) {
+              _searchController.clear();
+              _filteredItems.clear();
+            }
+          });
         });
   }
 }

--- a/lib/view/widgets/page_item_list_view.dart
+++ b/lib/view/widgets/page_item_list_view.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:settings/view/widgets/page_item.dart';
 
 const double _kScrollbarThickness = 8.0;
 const double _kScrollbarMargin = 2.0;
 
 class PageItemListView extends StatelessWidget {
-  PageItemListView(
+  const PageItemListView(
       {Key? key,
       required this.pages,
       required this.selectedIndex,
@@ -16,20 +15,19 @@ class PageItemListView extends StatelessWidget {
   final List<PageItem> pages;
   final int selectedIndex;
   final Function(int index) onTap;
-  final ItemScrollController scrollController = ItemScrollController();
 
   @override
   Widget build(BuildContext context) {
     final scrollbarThicknessWithTrack =
         _calcScrollbarThicknessWithTrack(context);
 
-    return ScrollablePositionedList.separated(
+    return ListView.separated(
         separatorBuilder: (_, __) => const SizedBox(height: 8.0),
         padding: EdgeInsets.symmetric(
           horizontal: scrollbarThicknessWithTrack,
           vertical: 8.0,
         ),
-        itemScrollController: scrollController,
+        controller: ScrollController(),
         itemCount: pages.length,
         itemBuilder: (context, index) {
           return DecoratedBox(

--- a/lib/view/widgets/portrait_layout.dart
+++ b/lib/view/widgets/portrait_layout.dart
@@ -39,15 +39,9 @@ class _PortraitLayoutState extends State<PortraitLayout> {
   }
 
   void onTap(int index) {
-    _searchActive = false;
     if (_filteredItems.isNotEmpty) {
-      for (var pageItem in widget.pages) {
-        if (pageItem.title == _filteredItems[index].title) {
-          index = widget.pages.indexOf(pageItem);
-          break;
-        }
-      }
-      _filteredItems.clear();
+      index = widget.pages.indexOf(widget.pages.firstWhere(
+          (pageItem) => pageItem.title == _filteredItems[index].title));
     }
 
     _navigator.push(pageRoute(index));
@@ -135,10 +129,7 @@ class _PortraitLayoutState extends State<PortraitLayout> {
               _filteredItems.clear();
             }),
         onTap: () {
-          setState(() {
-            _searchActive = true;
-            _searchController.clear();
-          });
+          setState(() => _searchActive = true);
         });
   }
 }

--- a/lib/view/widgets/portrait_layout.dart
+++ b/lib/view/widgets/portrait_layout.dart
@@ -47,6 +47,8 @@ class _PortraitLayoutState extends State<PortraitLayout> {
     _navigator.push(pageRoute(index));
     widget.onSelected(index);
     setState(() => _selectedIndex = index);
+    _searchController.clear();
+    _filteredItems.clear();
   }
 
   MaterialPageRoute pageRoute(int index) {
@@ -129,7 +131,13 @@ class _PortraitLayoutState extends State<PortraitLayout> {
               _filteredItems.clear();
             }),
         onTap: () {
-          setState(() => _searchActive = true);
+          setState(() {
+            _searchActive = !_searchActive;
+            if (!_searchActive) {
+              _searchController.clear();
+              _filteredItems.clear();
+            }
+          });
         });
   }
 }

--- a/lib/view/widgets/search_app_bar.dart
+++ b/lib/view/widgets/search_app_bar.dart
@@ -22,9 +22,8 @@ class SearchAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      leading: searchActive
-          ? null
-          : InkWell(child: const Icon(YaruIcons.search), onTap: () => onTap()),
+      leading:
+          InkWell(child: const Icon(YaruIcons.search), onTap: () => onTap()),
       title: searchActive
           ? RawKeyboardListener(
               onKey: (event) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   gsettings: ^0.1.2+1
   provider: ^5.0.0
   linux_system_info: ^0.0.7
-  scrollable_positioned_list: ^0.2.0-nullsafety.0
   dbus: ^0.6.3
   duration: ^3.0.6
   filesize: ^2.0.1


### PR DESCRIPTION
- do not clear the textfield after tab
- this makes a auto scroll list not needed anymore since the filter stays until you pressed ESC
- also cleaned-up the onTap methods

![fixsearch](https://user-images.githubusercontent.com/15329494/135754907-e6fef4dc-2258-4450-b2d1-ae4ac9b89034.gif)

Closes #82 
because we now handle the search click differently, if we want to revisit this feature we need to make it differently and probably also with a different package I think