### PR TITLE
wallpaper page fixes

### DIFF
--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -29,8 +29,12 @@ class WallpaperPage extends StatelessWidget {
         padding: const EdgeInsets.only(bottom: 20, top: 20),
         child: FilePickerRow(
             label: 'Your wallpaper',
-            onPressed: () async => model.pictureUri =
-                (await openFilePicker(context)) ?? model.pictureUri,
+            onPressed: () async {
+              final picPath = await openFilePicker(context);
+              if (null != picPath) {
+                model.pictureUri = picPath;
+              }
+            },
             pickingDescription: 'Browse'),
       ),
       SizedBox(

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -31,7 +31,7 @@ class WallpaperPage extends StatelessWidget {
             label: 'Your wallpaper',
             onPressed: () async => model.pictureUri =
                 (await openFilePicker(context)) ?? model.pictureUri,
-            pickingDescription: 'Select a wallpaper'),
+            pickingDescription: 'Browse'),
       ),
       SizedBox(
         width: 500,
@@ -129,13 +129,12 @@ class WallpaperPage extends StatelessWidget {
 
   Future<String?> openFilePicker(BuildContext context) async {
     return await FilesystemPicker.open(
-      title: 'Select a wallpaper',
-      allowedExtensions: ['.jpg', '.jpeg'],
-      context: context,
-      rootDirectory: Directory('/home/'),
-      fsType: FilesystemType.file,
-      pickText: 'Select a wallpaper',
-      folderIconColor: Theme.of(context).primaryColor.withOpacity(0.5),
-    );
+        title: 'Select a wallpaper',
+        allowedExtensions: ['.jpg', '.jpeg', '.png'],
+        context: context,
+        rootDirectory: Directory('/home/'),
+        fsType: FilesystemType.file,
+        pickText: 'Select a wallpaper',
+        fileTileSelectMode: FileTileSelectMode.wholeTile);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,11 @@ dependencies:
       url: https://github.com/canonical/upower.dart
   safe_change_notifier: ^0.0.1
   path_provider: ^2.0.5
-  filesystem_picker: ^2.0.0-nullsafety.0
+  filesystem_picker:
+    git:
+      url: https://github.com/Feichtmeier/filesystem_picker
+      path: package
+      ref: fix_breadcrump_color
   mime: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
- use Feichtmeier file picker fork until PR is merged to fix the breadcrump theme issue
- change picking description to 'Browse'
- use monochrome folder color
- don't use check selection for the picture
- add png's to allowed filetypes
- fix null picpath

Closes #116

![Peek 2021-10-04 15-59](https://user-images.githubusercontent.com/15329494/135865249-3daf6746-0e98-49da-96ef-e2f4521f9dec.gif)

