### PR TITLE
Use network_cellular icon

### DIFF
--- a/lib/view/pages/connections/connections_page.dart
+++ b/lib/view/pages/connections/connections_page.dart
@@ -54,7 +54,7 @@ class _ConnectionsPageState extends State<ConnectionsPage>
                     icon: Icon(YaruIcons.network_wired),
                     child: Text("Ethernet")),
                 Tab(
-                    icon: Icon(YaruIcons.call_incoming),
+                    icon: Icon(YaruIcons.network_cellular),
                     child: Text("Cellular")),
               ]),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
     git:
       url: https://github.com/canonical/upower.dart
   yaru: ^0.1.7
-  yaru_icons: ^0.0.6
+  yaru_icons: ^0.0.7
   yaru_widgets:
     git:
       url: https://github.com/ubuntu/yaru_widgets.dart


### PR DESCRIPTION
- Upgrade `yaru_icons` to 0.0.7 ;
- use `network_cellular` icon in "Connections" page.

Sadly I can't build and run the app:

```
Launching lib/main.dart on Linux in debug mode...
/snap/flutter/current/usr/bin/ld: warning: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/crt1.o: unsupported GNU_PROPERTY_TYPE (5) type: 0xc0008002
/snap/flutter/current/usr/bin/ld: warning: //lib/x86_64-linux-gnu/libdl.so.2: unsupported GNU_PROPERTY_TYPE (5) type: 0xc0008002
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Exception: Build process failed
Exited (sigterm)
```