### PR TITLE
Upgrade from Dart 2.12 to 2.15

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   dbus: ^0.6.3


### PR DESCRIPTION
Dart 2.15 has built-in string <-> enum conversions, which comes handy
when migrating from GSettings 0.1 to 0.2 (#183).

https://medium.com/dartlang/dart-2-15-7e7a598e508a#107a