### PR TITLE
Switch the CI from Flutter dev to stable

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'dev'
+          channel: 'stable'
 
       - name: Enable Linux desktop support
         run: flutter config --enable-linux-desktop


### PR DESCRIPTION
The dev channel is no longer updated:

https://medium.com/flutter/whats-new-in-flutter-2-8-d085b763d181#34c4