### PR TITLE
Abstract away GSettings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:bluez/bluez.dart';
 import 'package:flutter/material.dart';
-import 'package:gsettings/gsettings.dart';
 import 'package:nm/nm.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/schemas/schemas.dart';
@@ -18,7 +17,7 @@ import 'package:yaru_icons/widgets/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 void main() async {
-  final themeSettings = GSettings(schemaId: schemaInterface);
+  final themeSettings = Settings(schemaInterface);
 
   final networkManagerClient = NetworkManagerClient();
   await networkManagerClient.connect();

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,11 +1,11 @@
 import 'package:gsettings/gsettings.dart';
 
 class SettingsService {
-  final _settings = <String, GSettings?>{};
+  final _settings = <String, Settings?>{};
 
-  GSettings? lookup(String schemaId, {String? path}) {
+  Settings? lookup(String schemaId, {String? path}) {
     return _settings[schemaId] ??= GSettingsSchema.lookup(schemaId) != null
-        ? GSettings(schemaId: schemaId, path: path)
+        ? Settings(schemaId, path: path)
         : null;
   }
 
@@ -14,4 +14,26 @@ class SettingsService {
       settings?.dispose();
     }
   }
+}
+
+class Settings {
+  Settings(String schemaId, {String? path})
+      : _settings = GSettings(schemaId: schemaId, path: path);
+
+  final GSettings _settings;
+
+  void dispose() => _settings.dispose();
+
+  bool? boolValue(String key) => getValue<bool>(key);
+  int? intValue(String key) => getValue<int>(key);
+  double? doubleValue(String key) => getValue<double>(key);
+  String? stringValue(String key) => getValue<String>(key);
+  Iterable<String>? stringArrayValue(String key) =>
+      getValue<Iterable>(key)?.cast<String>();
+
+  T? getValue<T>(String key) => _settings.value(key) as T?;
+  void setValue<T>(String key, Object value) => _settings.setValue(key, value);
+  void resetValue(String key) => _settings.resetValue(key);
+
+  void sync() => _settings.sync();
 }

--- a/lib/view/app_theme.dart
+++ b/lib/view/app_theme.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:gsettings/gsettings.dart';
+import 'package:settings/services/settings_service.dart';
 
 class AppTheme extends ValueNotifier<ThemeMode> {
   AppTheme(this._settings) : super(ThemeMode.system);
 
-  final GSettings _settings;
+  final Settings _settings;
 
   void apply(Brightness brightness) {
     switch (brightness) {

--- a/lib/view/pages/accessibility/accessibility_model.dart
+++ b/lib/view/pages/accessibility/accessibility_model.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:gsettings/gsettings.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
@@ -71,15 +70,15 @@ class AccessibilityModel extends ChangeNotifier {
         _peripheralsKeyboardSettings =
             service.lookup(schemaPeripheralsKeyboard);
 
-  final GSettings? _desktopA11Settings;
-  final GSettings? _a11yAppsSettings;
-  final GSettings? _a11yKeyboardSettings;
-  final GSettings? _a11yMagnifierSettings;
-  final GSettings? _a11yMouseSettings;
-  final GSettings? _wmPreferencesSettings;
-  final GSettings? _interfaceSettings;
-  final GSettings? _peripheralsMouseSettings;
-  final GSettings? _peripheralsKeyboardSettings;
+  final Settings? _desktopA11Settings;
+  final Settings? _a11yAppsSettings;
+  final Settings? _a11yKeyboardSettings;
+  final Settings? _a11yMagnifierSettings;
+  final Settings? _a11yMouseSettings;
+  final Settings? _wmPreferencesSettings;
+  final Settings? _interfaceSettings;
+  final Settings? _peripheralsMouseSettings;
+  final Settings? _peripheralsKeyboardSettings;
 
   // Global section
 
@@ -206,9 +205,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   bool? get crossHairsClip {
-    if (_a11yMagnifierSettings != null) {
-      return !_a11yMagnifierSettings!.boolValue(_crossHairsClipKey);
-    }
+    return _a11yMagnifierSettings?.boolValue(_crossHairsClipKey) == false;
   }
 
   void setCrossHairsClip(bool value) {
@@ -217,7 +214,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   double? get crossHairsThickness =>
-      _a11yMagnifierSettings?.intValue(_crossHairsThicknessKey).toDouble();
+      _a11yMagnifierSettings?.intValue(_crossHairsThicknessKey)?.toDouble();
 
   void setCrossHairsThickness(double value) {
     _a11yMagnifierSettings?.setValue(_crossHairsThicknessKey, value.toInt());
@@ -225,7 +222,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   double? get crossHairsLength =>
-      _a11yMagnifierSettings?.intValue(_crossHairsLengthKey).toDouble();
+      _a11yMagnifierSettings?.intValue(_crossHairsLengthKey)?.toDouble();
 
   void setCrossHairsLength(double value) {
     _a11yMagnifierSettings?.setValue(_crossHairsLengthKey, value.toInt());
@@ -315,7 +312,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   double? get delay =>
-      _peripheralsKeyboardSettings?.intValue(_delayKeyboardKey).toDouble();
+      _peripheralsKeyboardSettings?.intValue(_delayKeyboardKey)?.toDouble();
 
   void setDelay(double value) {
     _peripheralsKeyboardSettings?.setValue(_delayKeyboardKey, value.toInt());
@@ -324,7 +321,7 @@ class AccessibilityModel extends ChangeNotifier {
 
   double? get interval => _peripheralsKeyboardSettings
       ?.intValue(_repeatIntervalKeyboardKey)
-      .toDouble();
+      ?.toDouble();
 
   void setInterval(double value) {
     _peripheralsKeyboardSettings?.setValue(
@@ -340,7 +337,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   double? get cursorBlinkTime =>
-      _interfaceSettings?.intValue(_cursorBlinkTimeKey).toDouble();
+      _interfaceSettings?.intValue(_cursorBlinkTimeKey)?.toDouble();
 
   void setCursorBlinkTime(double value) {
     _interfaceSettings?.setValue(_cursorBlinkTimeKey, value.toInt());
@@ -391,7 +388,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   double? get slowKeysDelay =>
-      _a11yKeyboardSettings?.intValue(_slowKeysDelayKey).toDouble();
+      _a11yKeyboardSettings?.intValue(_slowKeysDelayKey)?.toDouble();
 
   void setSlowKeysDelay(double value) {
     _a11yKeyboardSettings?.setValue(_slowKeysDelayKey, value.toInt());
@@ -430,7 +427,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   double? get bounceKeysDelay =>
-      _a11yKeyboardSettings?.intValue(_bounceKeysDelayKey).toDouble();
+      _a11yKeyboardSettings?.intValue(_bounceKeysDelayKey)?.toDouble();
 
   void setBounceKeysDelay(double value) {
     _a11yKeyboardSettings?.setValue(_bounceKeysDelayKey, value.toInt());
@@ -461,7 +458,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   double? get doubleClickDelay =>
-      _peripheralsMouseSettings?.intValue(_doubleClickDelayKey).toDouble();
+      _peripheralsMouseSettings?.intValue(_doubleClickDelayKey)?.toDouble();
 
   void setDoubleClickDelay(double value) {
     _peripheralsMouseSettings?.setValue(_doubleClickDelayKey, value.toInt());
@@ -504,7 +501,7 @@ class AccessibilityModel extends ChangeNotifier {
   }
 
   double? get dwellThreshold =>
-      _a11yMouseSettings?.intValue(_dwellThresholdKey).toDouble();
+      _a11yMouseSettings?.intValue(_dwellThresholdKey)?.toDouble();
 
   void setDwellThreshold(double value) {
     _a11yMouseSettings?.setValue(_dwellThresholdKey, value.toInt());

--- a/lib/view/pages/appearance/appearance_model.dart
+++ b/lib/view/pages/appearance/appearance_model.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:gsettings/gsettings.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
@@ -15,7 +14,7 @@ class AppearanceModel extends ChangeNotifier {
   AppearanceModel(SettingsService service)
       : _dashToDockSettings = service.lookup(schemaDashToDock);
 
-  final GSettings? _dashToDockSettings;
+  final Settings? _dashToDockSettings;
 
   // Dock section
 
@@ -48,7 +47,7 @@ class AppearanceModel extends ChangeNotifier {
   }
 
   double? get maxIconSize =>
-      _dashToDockSettings?.intValue(_dashMaxIconSizeKey).toDouble();
+      _dashToDockSettings?.intValue(_dashMaxIconSizeKey)?.toDouble();
 
   void setMaxIconSize(double value) {
     var intValue = value.toInt();

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcuts_model.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcuts_model.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:gsettings/gsettings.dart';
 import 'package:settings/services/settings_service.dart';
 
 class KeyboardShortcutsModel extends ChangeNotifier {
@@ -8,7 +7,7 @@ class KeyboardShortcutsModel extends ChangeNotifier {
   KeyboardShortcutsModel(SettingsService service, {required this.schemaId})
       : _shortcutSettings = service.lookup(schemaId);
 
-  final GSettings? _shortcutSettings;
+  final Settings? _shortcutSettings;
 
   List<String> shortcut(String shortcutId) {
     final keys = _shortcutSettings?.stringArrayValue(shortcutId);

--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:gsettings/gsettings.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
@@ -16,8 +15,8 @@ class MouseAndTouchpadModel extends ChangeNotifier {
             service.lookup(schemaDesktopPeripheralsMouse),
         _peripheralsTouchpadSettings = service.lookup(schemaPeripheralTouchpad);
 
-  final GSettings? _peripheralsMouseSettings;
-  final GSettings? _peripheralsTouchpadSettings;
+  final Settings? _peripheralsMouseSettings;
+  final Settings? _peripheralsTouchpadSettings;
 
   // Mouse section
 

--- a/lib/view/pages/notifications/notifications_model.dart
+++ b/lib/view/pages/notifications/notifications_model.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:gsettings/gsettings.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
@@ -10,14 +9,12 @@ class NotificationsModel extends ChangeNotifier {
   NotificationsModel(SettingsService service)
       : _notificationSettings = service.lookup(schemaNotifications);
 
-  final GSettings? _notificationSettings;
+  final Settings? _notificationSettings;
 
   // Global section
 
   bool? get doNotDisturb {
-    if (_notificationSettings != null) {
-      return !_notificationSettings!.boolValue(_showBannersKey);
-    }
+    return _notificationSettings?.boolValue(_showBannersKey) == false;
   }
 
   void setDoNotDisturb(bool value) {
@@ -37,7 +34,7 @@ class NotificationsModel extends ChangeNotifier {
 
   List<String>? get applications => _notificationSettings
       ?.stringArrayValue('application-children')
-      .whereType<String>()
+      ?.whereType<String>()
       .toList();
 }
 
@@ -50,7 +47,7 @@ class AppNotificationsModel extends ChangeNotifier {
             service.lookup(_appSchemaId, path: _getPath(appId));
 
   final String appId;
-  final GSettings? _appNotificationSettings;
+  final Settings? _appNotificationSettings;
 
   static String _getPath(String appId) {
     return '/' +

--- a/lib/view/pages/power/power_settings.dart
+++ b/lib/view/pages/power/power_settings.dart
@@ -34,10 +34,13 @@ enum SleepInactiveType {
   logout,
 }
 
-extension SleepInactiveTypeInt on int {
+extension SleepInactiveTypeString on String {
   SleepInactiveType? toSleepInactiveType() {
-    if (this < 0 || this >= SleepInactiveType.values.length) return null;
-    return SleepInactiveType.values[this];
+    try {
+      return SleepInactiveType.values.byName(this);
+    } on ArgumentError {
+      return null;
+    }
   }
 }
 

--- a/lib/view/pages/power/power_settings_model.dart
+++ b/lib/view/pages/power/power_settings_model.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:gsettings/gsettings.dart';
 import 'package:nm/nm.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:settings/services/bluetooth_service.dart';
@@ -23,8 +22,8 @@ class SuspendModel extends SafeChangeNotifier {
         _bluetoothService = bluetooth,
         _networkManager = network;
 
-  final GSettings? _daemonSettings;
-  final GSettings? _sessionSettings;
+  final Settings? _daemonSettings;
+  final Settings? _sessionSettings;
   final BluetoothService _bluetoothService;
   final NetworkManagerClient _networkManager;
   final PowerSettingsService _powerService;
@@ -105,9 +104,9 @@ class SuspendModel extends SafeChangeNotifier {
   }
 
   SleepInactiveType? _sleepInactiveType(String key) =>
-      (_daemonSettings?.enumValue(key) ?? -1).toSleepInactiveType();
+      _daemonSettings?.stringValue(key)?.toSleepInactiveType();
   void _setSleepInactiveType(String key, SleepInactiveType value) {
-    _daemonSettings?.setEnumValue(key, value.index);
+    _daemonSettings?.setValue(key, value.name);
     notifyListeners();
   }
 

--- a/lib/view/pages/power/suspend.dart
+++ b/lib/view/pages/power/suspend.dart
@@ -7,10 +7,13 @@ enum PowerButtonAction {
   interactive,
 }
 
-extension PowerButtonActionInt on int {
+extension PowerButtonActionString on String {
   PowerButtonAction? toPowerButtonAction() {
-    if (this < 0 || this >= PowerButtonAction.values.length) return null;
-    return PowerButtonAction.values[this];
+    try {
+      return PowerButtonAction.values.byName(this);
+    } on ArgumentError {
+      return null;
+    }
   }
 }
 

--- a/lib/view/pages/power/suspend_model.dart
+++ b/lib/view/pages/power/suspend_model.dart
@@ -1,4 +1,3 @@
-import 'package:gsettings/gsettings.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/power/suspend.dart';
@@ -11,8 +10,8 @@ class SuspendModel extends SafeChangeNotifier {
       : _daemonSettings = settings.lookup(_kDaemonSchema),
         _interfaceSettings = settings.lookup(_kInterfaceSchema);
 
-  final GSettings? _daemonSettings;
-  final GSettings? _interfaceSettings;
+  final Settings? _daemonSettings;
+  final Settings? _interfaceSettings;
 
   bool? get showBatteryPercentage =>
       _interfaceSettings?.boolValue('show-battery-percentage');
@@ -21,12 +20,12 @@ class SuspendModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  PowerButtonAction? get powerButtonAction =>
-      (_daemonSettings?.enumValue('power-button-action') ?? -1)
-          .toPowerButtonAction();
+  PowerButtonAction? get powerButtonAction => _daemonSettings
+      ?.stringValue('power-button-action')
+      ?.toPowerButtonAction();
   void setPowerButtonAction(PowerButtonAction? value) {
     if (value == null) return;
-    _daemonSettings?.setEnumValue('power-button-action', value.index);
+    _daemonSettings?.setValue('power-button-action', value.name);
     notifyListeners();
   }
 }

--- a/lib/view/pages/removable_media/removable_media_model.dart
+++ b/lib/view/pages/removable_media/removable_media_model.dart
@@ -1,4 +1,3 @@
-import 'package:gsettings/gsettings.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
@@ -33,14 +32,15 @@ class RemovableMediaModel extends SafeChangeNotifier {
     'Ask'
   ];
 
-  final GSettings? _removableMediaSettings;
+  final Settings? _removableMediaSettings;
 
   RemovableMediaModel(SettingsService service)
       : _removableMediaSettings = service.lookup(schemaMediaHandling);
 
   // autorun-never
   final _autoRunNeverKey = 'autorun-never';
-  bool get autoRunNever => _removableMediaSettings!.boolValue(_autoRunNeverKey);
+  bool get autoRunNever =>
+      _removableMediaSettings?.boolValue(_autoRunNeverKey) == true;
   set autoRunNever(bool value) {
     _removableMediaSettings!.setValue(_autoRunNeverKey, value);
     notifyListeners();

--- a/lib/view/pages/sound/sound_model.dart
+++ b/lib/view/pages/sound/sound_model.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:gsettings/gsettings.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
@@ -11,7 +10,7 @@ class SoundModel extends ChangeNotifier {
   SoundModel(SettingsService service)
       : _soundSettings = service.lookup(schemaSound);
 
-  final GSettings? _soundSettings;
+  final Settings? _soundSettings;
 
   // System section
 

--- a/lib/view/pages/wallpaper/color_shading_option_row.dart
+++ b/lib/view/pages/wallpaper/color_shading_option_row.dart
@@ -74,7 +74,7 @@ class ColorShadingOptionRow extends StatelessWidget {
     final buffer = StringBuffer();
     if (hexString.length == 6 || hexString.length == 7) buffer.write('ff');
     buffer.write(hexString.replaceFirst('#', ''));
-    return Color(int.parse(buffer.toString(), radix: 16));
+    return Color(int.tryParse(buffer.toString(), radix: 16) ?? 0);
   }
 
   Future<bool> colorPickerDialog(BuildContext context, bool primary) async {

--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -1,13 +1,12 @@
 import 'dart:io';
 
-import 'package:gsettings/gsettings.dart';
 import 'package:mime/mime.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
 class WallpaperModel extends SafeChangeNotifier {
-  final GSettings? _wallpaperSettings;
+  final Settings? _wallpaperSettings;
   static const _pictureUriKey = 'picture-uri';
   static const _preinstalledWallpapersDir = '/usr/share/backgrounds';
   static const _colorShadingTypeKey = 'color-shading-type';
@@ -20,7 +19,8 @@ class WallpaperModel extends SafeChangeNotifier {
   WallpaperModel(SettingsService service)
       : _wallpaperSettings = service.lookup(schemaBackground);
 
-  String get pictureUri => _wallpaperSettings!.stringValue(_pictureUriKey);
+  String get pictureUri =>
+      _wallpaperSettings!.stringValue(_pictureUriKey) ?? '';
 
   set pictureUri(String picPathString) {
     _wallpaperSettings!.setValue(
@@ -51,7 +51,8 @@ class WallpaperModel extends SafeChangeNotifier {
         .where((element) => lookupMimeType(element.path)!.startsWith('image/'));
   }
 
-  String get primaryColor => _wallpaperSettings!.stringValue(_primaryColorKey);
+  String get primaryColor =>
+      _wallpaperSettings!.stringValue(_primaryColorKey) ?? '';
 
   set primaryColor(String colorHexValueString) {
     _wallpaperSettings!.setValue(_primaryColorKey, colorHexValueString);
@@ -59,7 +60,7 @@ class WallpaperModel extends SafeChangeNotifier {
   }
 
   String get secondaryColor =>
-      _wallpaperSettings!.stringValue(_secondaryColorKey);
+      _wallpaperSettings!.stringValue(_secondaryColorKey) ?? '';
 
   set secondaryColor(String colorHexValueString) {
     _wallpaperSettings!.setValue(_secondaryColorKey, colorHexValueString);

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -220,6 +220,6 @@ class WallpaperPage extends StatelessWidget {
     final buffer = StringBuffer();
     if (hexString.length == 6 || hexString.length == 7) buffer.write('ff');
     buffer.write(hexString.replaceFirst('#', ''));
-    return Color(int.parse(buffer.toString(), radix: 16));
+    return Color(int.tryParse(buffer.toString(), radix: 16) ?? 0);
   }
 }

--- a/test/widgets/app_theme_test.dart
+++ b/test/widgets/app_theme_test.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gsettings/gsettings.dart';
 import 'package:mockito/annotations.dart';
+import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/app_theme.dart';
 import 'app_theme_test.mocks.dart';
 import 'package:mockito/mockito.dart';
 
-@GenerateMocks([GSettings])
+@GenerateMocks([Settings])
 void main() {
   test(
     'App Theme Dark Mode Test',
     () {
-      GSettings settings = MockGSettings();
+      Settings settings = MockSettings();
       AppTheme theme = AppTheme(settings);
 
       when(settings.setValue('gtk-theme', 'Yaru-dark')).thenAnswer(
@@ -26,7 +26,7 @@ void main() {
   test(
     'App Theme Light Mode Test',
     () {
-      GSettings settings = MockGSettings();
+      Settings settings = MockSettings();
       AppTheme theme = AppTheme(settings);
 
       when(settings.setValue('gtk-theme', 'Yaru')).thenAnswer(

--- a/test/widgets/app_theme_test.mocks.dart
+++ b/test/widgets/app_theme_test.mocks.dart
@@ -2,12 +2,8 @@
 // in settings/test/widgets/app_theme_test.dart.
 // Do not manually edit this file.
 
-import 'dart:ffi' as _i1;
-
-import 'package:gsettings/src/bindings.dart' as _i5;
-import 'package:gsettings/src/settings.dart' as _i3;
-import 'package:mockito/mockito.dart' as _i2;
-import 'package:more/more.dart' as _i4;
+import 'package:mockito/mockito.dart' as _i1;
+import 'package:settings/services/settings_service.dart' as _i2;
 
 // ignore_for_file: avoid_redundant_argument_values
 // ignore_for_file: avoid_setters_without_getters
@@ -18,135 +14,47 @@ import 'package:more/more.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 
-
-class _FakeGSettings_1 extends _i2.Fake implements _i3.GSettings {}
-
-class _FakeTuple_2 extends _i2.Fake implements _i4.Tuple {}
-
-/// A class which mocks [GSettings].
+/// A class which mocks [Settings].
 ///
 /// See the documentation for Mockito's code generation for more information.
-// ignore: must_be_immutable
-class MockGSettings extends _i2.Mock implements _i3.GSettings {
-  MockGSettings() {
-    _i2.throwOnMissingStub(this);
+class MockSettings extends _i1.Mock implements _i2.Settings {
+  MockSettings() {
+    _i1.throwOnMissingStub(this);
   }
 
-  @override
-  List<Object> get props =>
-      (super.noSuchMethod(Invocation.getter(#props), returnValue: <Object>[])
-          as List<Object>);
-  @override
-  String get schemaId =>
-      (super.noSuchMethod(Invocation.getter(#schemaId), returnValue: '')
-          as String);
-  @override
-  String get path =>
-      (super.noSuchMethod(Invocation.getter(#path), returnValue: '') as String);
-
-  @override
-  void sync() => super.noSuchMethod(Invocation.method(#sync, []),
-      returnValueForMissingStub: null);
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);
   @override
-  Object? value(String? key) =>
-      (super.noSuchMethod(Invocation.method(#value, [key])) as Object?);
+  bool? boolValue(String? key) =>
+      (super.noSuchMethod(Invocation.method(#boolValue, [key])) as bool?);
   @override
-  bool setValue(String? key, Object? value) =>
-      (super.noSuchMethod(Invocation.method(#setValue, [key, value]),
-          returnValue: false) as bool);
+  int? intValue(String? key) =>
+      (super.noSuchMethod(Invocation.method(#intValue, [key])) as int?);
   @override
-  bool isWritable(String? key) =>
-      (super.noSuchMethod(Invocation.method(#isWritable, [key]),
-          returnValue: false) as bool);
+  double? doubleValue(String? key) =>
+      (super.noSuchMethod(Invocation.method(#doubleValue, [key])) as double?);
   @override
-  void delay() => super.noSuchMethod(Invocation.method(#delay, []),
-      returnValueForMissingStub: null);
+  String? stringValue(String? key) =>
+      (super.noSuchMethod(Invocation.method(#stringValue, [key])) as String?);
   @override
-  void apply() => super.noSuchMethod(Invocation.method(#apply, []),
-      returnValueForMissingStub: null);
+  Iterable<String>? stringArrayValue(String? key) =>
+      (super.noSuchMethod(Invocation.method(#stringArrayValue, [key]))
+          as Iterable<String>?);
   @override
-  void revert() => super.noSuchMethod(Invocation.method(#revert, []),
-      returnValueForMissingStub: null);
+  T? getValue<T>(String? key) =>
+      (super.noSuchMethod(Invocation.method(#getValue, [key])) as T?);
   @override
-  bool hasUnapplied() =>
-      (super.noSuchMethod(Invocation.method(#hasUnapplied, []),
-          returnValue: false) as bool);
-  @override
-  _i3.GSettings child(String? name) =>
-      (super.noSuchMethod(Invocation.method(#child, [name]),
-          returnValue: _FakeGSettings_1()) as _i3.GSettings);
+  void setValue<T>(String? key, Object? value) =>
+      super.noSuchMethod(Invocation.method(#setValue, [key, value]),
+          returnValueForMissingStub: null);
   @override
   void resetValue(String? key) =>
       super.noSuchMethod(Invocation.method(#resetValue, [key]),
           returnValueForMissingStub: null);
   @override
-  Object? userValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#userValue, [key])) as Object?);
-  @override
-  Object? defaultValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#defaultValue, [key])) as Object?);
-  @override
-  List<String> children() =>
-      (super.noSuchMethod(Invocation.method(#children, []),
-          returnValue: <String>[]) as List<String>);
-  @override
-  bool boolValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#boolValue, [key]),
-          returnValue: false) as bool);
-  @override
-  int intValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#intValue, [key]), returnValue: 0)
-          as int);
-  @override
-  double doubleValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#doubleValue, [key]),
-          returnValue: 0.0) as double);
-  @override
-  String stringValue(String? key) => (super
-          .noSuchMethod(Invocation.method(#stringValue, [key]), returnValue: '')
-      as String);
-  @override
-  Object? maybeValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#maybeValue, [key])) as Object?);
-  @override
-  Map<Object, Object?> dictValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#dictValue, [key]),
-          returnValue: <Object, Object?>{}) as Map<Object, Object?>);
-  @override
-  List<Object?> arrayValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#arrayValue, [key]),
-          returnValue: <Object?>[]) as List<Object?>);
-  @override
-  List<int?> byteArrayValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#byteArrayValue, [key]),
-          returnValue: <int?>[]) as List<int?>);
-  @override
-  List<String?> stringArrayValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#stringArrayValue, [key]),
-          returnValue: <String?>[]) as List<String?>);
-  @override
-  _i4.Tuple tupleValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#tupleValue, [key]),
-          returnValue: _FakeTuple_2()) as _i4.Tuple);
-  @override
-  int enumValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#enumValue, [key]), returnValue: 0)
-          as int);
-  @override
-  bool setEnumValue(String? key, int? value) =>
-      (super.noSuchMethod(Invocation.method(#setEnumValue, [key, value]),
-          returnValue: false) as bool);
-  @override
-  int flagsValue(String? key) =>
-      (super.noSuchMethod(Invocation.method(#flagsValue, [key]), returnValue: 0)
-          as int);
-  @override
-  bool setFlagsValue(String? key, int? value) =>
-      (super.noSuchMethod(Invocation.method(#setFlagsValue, [key, value]),
-          returnValue: false) as bool);
+  void sync() => super.noSuchMethod(Invocation.method(#sync, []),
+      returnValueForMissingStub: null);
   @override
   String toString() => super.toString();
 }


### PR DESCRIPTION
This is a preparation step for #183 i.e. migrating from GSettings 0.1
to 0.2.

GSettings 0.1 and 0.2 are vastly different because the FFI-based 0.1 is
synchronous, whereas the D-Bus-based 0.2 is asynchronous. Furthermore,
0.1 has separate getters for different primitive types, whereas 0.2 has
only one getter that returns a DBusValue.

In order to make the migration from GSettings 0.1 to 0.2 easier, hide
GSettings instances from the models and use nullable setting values to
eliminate the assumption that setting values are immediately available.