### PR TITLE
Prepare settings listeners

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:gsettings/gsettings.dart';
 
 class SettingsService {
@@ -21,6 +23,15 @@ class Settings {
       : _settings = GSettings(schemaId: schemaId, path: path);
 
   final GSettings _settings;
+  final _listeners = <VoidCallback>{};
+
+  void addListener(VoidCallback listener) => _listeners.add(listener);
+  void removeListener(VoidCallback listener) => _listeners.remove(listener);
+  void notifyListeners() {
+    for (final listener in _listeners) {
+      listener();
+    }
+  }
 
   void dispose() => _settings.dispose();
 

--- a/lib/view/pages/accessibility/accessibility_model.dart
+++ b/lib/view/pages/accessibility/accessibility_model.dart
@@ -68,7 +68,31 @@ class AccessibilityModel extends ChangeNotifier {
         _interfaceSettings = service.lookup(schemaInterface),
         _peripheralsMouseSettings = service.lookup(schemaPeripheralsMouse),
         _peripheralsKeyboardSettings =
-            service.lookup(schemaPeripheralsKeyboard);
+            service.lookup(schemaPeripheralsKeyboard) {
+    _desktopA11Settings?.addListener(notifyListeners);
+    _a11yAppsSettings?.addListener(notifyListeners);
+    _a11yKeyboardSettings?.addListener(notifyListeners);
+    _a11yMagnifierSettings?.addListener(notifyListeners);
+    _a11yMouseSettings?.addListener(notifyListeners);
+    _wmPreferencesSettings?.addListener(notifyListeners);
+    _interfaceSettings?.addListener(notifyListeners);
+    _peripheralsMouseSettings?.addListener(notifyListeners);
+    _peripheralsKeyboardSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _desktopA11Settings?.removeListener(notifyListeners);
+    _a11yAppsSettings?.removeListener(notifyListeners);
+    _a11yKeyboardSettings?.removeListener(notifyListeners);
+    _a11yMagnifierSettings?.removeListener(notifyListeners);
+    _a11yMouseSettings?.removeListener(notifyListeners);
+    _wmPreferencesSettings?.removeListener(notifyListeners);
+    _interfaceSettings?.removeListener(notifyListeners);
+    _peripheralsMouseSettings?.removeListener(notifyListeners);
+    _peripheralsKeyboardSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   final Settings? _desktopA11Settings;
   final Settings? _a11yAppsSettings;

--- a/lib/view/pages/appearance/appearance_model.dart
+++ b/lib/view/pages/appearance/appearance_model.dart
@@ -12,7 +12,15 @@ class AppearanceModel extends ChangeNotifier {
   static const _clickActionKey = 'click-action';
 
   AppearanceModel(SettingsService service)
-      : _dashToDockSettings = service.lookup(schemaDashToDock);
+      : _dashToDockSettings = service.lookup(schemaDashToDock) {
+    _dashToDockSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _dashToDockSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   final Settings? _dashToDockSettings;
 

--- a/lib/view/pages/keyboard_shortcuts/keyboard_shortcuts_model.dart
+++ b/lib/view/pages/keyboard_shortcuts/keyboard_shortcuts_model.dart
@@ -5,7 +5,15 @@ class KeyboardShortcutsModel extends ChangeNotifier {
   final String schemaId;
 
   KeyboardShortcutsModel(SettingsService service, {required this.schemaId})
-      : _shortcutSettings = service.lookup(schemaId);
+      : _shortcutSettings = service.lookup(schemaId) {
+    _shortcutSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _shortcutSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   final Settings? _shortcutSettings;
 

--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
@@ -13,7 +13,18 @@ class MouseAndTouchpadModel extends ChangeNotifier {
   MouseAndTouchpadModel(SettingsService service)
       : _peripheralsMouseSettings =
             service.lookup(schemaDesktopPeripheralsMouse),
-        _peripheralsTouchpadSettings = service.lookup(schemaPeripheralTouchpad);
+        _peripheralsTouchpadSettings =
+            service.lookup(schemaPeripheralTouchpad) {
+    _peripheralsMouseSettings?.addListener(notifyListeners);
+    _peripheralsTouchpadSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _peripheralsMouseSettings?.removeListener(notifyListeners);
+    _peripheralsTouchpadSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   final Settings? _peripheralsMouseSettings;
   final Settings? _peripheralsTouchpadSettings;

--- a/lib/view/pages/notifications/notifications_model.dart
+++ b/lib/view/pages/notifications/notifications_model.dart
@@ -7,7 +7,15 @@ class NotificationsModel extends ChangeNotifier {
   static const _showInLockScreenKey = 'show-in-lock-screen';
 
   NotificationsModel(SettingsService service)
-      : _notificationSettings = service.lookup(schemaNotifications);
+      : _notificationSettings = service.lookup(schemaNotifications) {
+    _notificationSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _notificationSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   final Settings? _notificationSettings;
 
@@ -44,7 +52,15 @@ class AppNotificationsModel extends ChangeNotifier {
 
   AppNotificationsModel(this.appId, SettingsService service)
       : _appNotificationSettings =
-            service.lookup(_appSchemaId, path: _getPath(appId));
+            service.lookup(_appSchemaId, path: _getPath(appId)) {
+    _appNotificationSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _appNotificationSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   final String appId;
   final Settings? _appNotificationSettings;

--- a/lib/view/pages/power/power_settings_model.dart
+++ b/lib/view/pages/power/power_settings_model.dart
@@ -20,7 +20,10 @@ class SuspendModel extends SafeChangeNotifier {
         _sessionSettings = settings.lookup(_kSessionSchema),
         _powerService = power,
         _bluetoothService = bluetooth,
-        _networkManager = network;
+        _networkManager = network {
+    _daemonSettings?.addListener(notifyListeners);
+    _sessionSettings?.addListener(notifyListeners);
+  }
 
   final Settings? _daemonSettings;
   final Settings? _sessionSettings;
@@ -53,6 +56,8 @@ class SuspendModel extends SafeChangeNotifier {
 
   @override
   Future<void> dispose() async {
+    _daemonSettings?.removeListener(notifyListeners);
+    _sessionSettings?.removeListener(notifyListeners);
     await _airplaneMode?.cancel();
     await _screenBrightness?.cancel();
     await _keyboardBrightness?.cancel();

--- a/lib/view/pages/power/suspend_model.dart
+++ b/lib/view/pages/power/suspend_model.dart
@@ -8,7 +8,17 @@ const _kInterfaceSchema = 'org.gnome.desktop.interface';
 class SuspendModel extends SafeChangeNotifier {
   SuspendModel(SettingsService settings)
       : _daemonSettings = settings.lookup(_kDaemonSchema),
-        _interfaceSettings = settings.lookup(_kInterfaceSchema);
+        _interfaceSettings = settings.lookup(_kInterfaceSchema) {
+    _daemonSettings?.addListener(notifyListeners);
+    _interfaceSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _daemonSettings?.removeListener(notifyListeners);
+    _interfaceSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   final Settings? _daemonSettings;
   final Settings? _interfaceSettings;

--- a/lib/view/pages/removable_media/removable_media_model.dart
+++ b/lib/view/pages/removable_media/removable_media_model.dart
@@ -35,7 +35,15 @@ class RemovableMediaModel extends SafeChangeNotifier {
   final Settings? _removableMediaSettings;
 
   RemovableMediaModel(SettingsService service)
-      : _removableMediaSettings = service.lookup(schemaMediaHandling);
+      : _removableMediaSettings = service.lookup(schemaMediaHandling) {
+    _removableMediaSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _removableMediaSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   // autorun-never
   final _autoRunNeverKey = 'autorun-never';

--- a/lib/view/pages/sound/sound_model.dart
+++ b/lib/view/pages/sound/sound_model.dart
@@ -8,7 +8,15 @@ class SoundModel extends ChangeNotifier {
   static const _inputFeedbackSounds = 'input-feedback-sounds';
 
   SoundModel(SettingsService service)
-      : _soundSettings = service.lookup(schemaSound);
+      : _soundSettings = service.lookup(schemaSound) {
+    _soundSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _soundSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   final Settings? _soundSettings;
 

--- a/lib/view/pages/wallpaper/wallpaper_model.dart
+++ b/lib/view/pages/wallpaper/wallpaper_model.dart
@@ -17,7 +17,15 @@ class WallpaperModel extends SafeChangeNotifier {
   String? _customDir;
 
   WallpaperModel(SettingsService service)
-      : _wallpaperSettings = service.lookup(schemaBackground);
+      : _wallpaperSettings = service.lookup(schemaBackground) {
+    _wallpaperSettings?.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _wallpaperSettings?.removeListener(notifyListeners);
+    super.dispose();
+  }
 
   String get pictureUri =>
       _wallpaperSettings!.stringValue(_pictureUriKey) ?? '';

--- a/test/widgets/app_theme_test.mocks.dart
+++ b/test/widgets/app_theme_test.mocks.dart
@@ -2,6 +2,8 @@
 // in settings/test/widgets/app_theme_test.dart.
 // Do not manually edit this file.
 
+import 'dart:ui' as _i3;
+
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:settings/services/settings_service.dart' as _i2;
 
@@ -22,6 +24,18 @@ class MockSettings extends _i1.Mock implements _i2.Settings {
     _i1.throwOnMissingStub(this);
   }
 
+  @override
+  void addListener(_i3.VoidCallback? listener) =>
+      super.noSuchMethod(Invocation.method(#addListener, [listener]),
+          returnValueForMissingStub: null);
+  @override
+  void removeListener(_i3.VoidCallback? listener) =>
+      super.noSuchMethod(Invocation.method(#removeListener, [listener]),
+          returnValueForMissingStub: null);
+  @override
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []),
+          returnValueForMissingStub: null);
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
       returnValueForMissingStub: null);


### PR DESCRIPTION
With gsettings.dart 0.2 (#183) we can have change notifications. This
commit sets up the infrastructure for that, offloading noise from the
actual migration step that follows later when the blocker issues in
gsettings.dart have been resolved.