### PR TITLE
Fix peripherals mouse schema

### DIFF
--- a/lib/schemas/schemas.dart
+++ b/lib/schemas/schemas.dart
@@ -9,10 +9,7 @@ const String schemaPeripheralsKeyboard =
 const String schemaWmPreferences = 'org.gnome.desktop.wm.preferences';
 const schemaWmKeybindings = 'org.gnome.desktop.wm.keybindings';
 const schemaGnomeShellKeybinding = 'org.gnome.shell.keybindings';
-const String schemaPeripheralsMouse =
-    'org.gnome.settings-daemon.peripherals.mouse';
-const String schemaDesktopPeripheralsMouse =
-    'org.gnome.desktop.peripherals.mouse';
+const String schemaPeripheralsMouse = 'org.gnome.desktop.peripherals.mouse';
 const String schemaPeripheralTouchpad =
     'org.gnome.desktop.peripherals.touchpad';
 const String schemaSound = 'org.gnome.desktop.sound';

--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
@@ -11,8 +11,7 @@ class MouseAndTouchpadModel extends ChangeNotifier {
   static const _touchpadDisableWhileTyping = 'disable-while-typing';
 
   MouseAndTouchpadModel(SettingsService service)
-      : _peripheralsMouseSettings =
-            service.lookup(schemaDesktopPeripheralsMouse),
+      : _peripheralsMouseSettings = service.lookup(schemaPeripheralsMouse),
         _peripheralsTouchpadSettings =
             service.lookup(schemaPeripheralTouchpad) {
     _peripheralsMouseSettings?.addListener(notifyListeners);


### PR DESCRIPTION
Use `org.gnome.desktop.peripherals.mouse` instead of the deprecated
`org.gnome.settings-daemon.peripherals.mouse` schema (that has been
removed in Impish?).

https://gitlab.gnome.org/GNOME/gnome-settings-daemon/blob/master/data/org.gnome.settings-daemon.peripherals.gschema.xml.in#L46