### PR TITLE
Use SpinBox instead of Slider for Magnification setting

### DIFF
--- a/lib/view/pages/accessibility/seeing_section.dart
+++ b/lib/view/pages/accessibility/seeing_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/view/pages/accessibility/accessibility_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -209,14 +210,24 @@ class _MagnifierOptions extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          YaruSliderSecondary(
-            // TODO it'd be better to use SpinBox instead of Slider
-            label: 'Magnification',
-            enabled: true,
-            min: 1,
-            max: 20,
-            value: model.magFactor,
-            onChanged: (value) => model.setMagFactor(value),
+          YaruRow(
+            trailingWidget: const Text('Magnification'),
+            actionWidget: SizedBox(
+              height: 40,
+              width: 150,
+              child: SpinBox(
+                decoration: const InputDecoration(
+                  border: UnderlineInputBorder(),
+                ),
+                enabled: true,
+                min: 1,
+                max: 20,
+                step: 0.25,
+                decimals: 2,
+                value: model.magFactor ?? 2,
+                onChanged: (value) => model.setMagFactor(value),
+              ),
+            ),
           ),
           const Text('Magnifier Position'),
           const _MagnifierPositionOptions(),


### PR DESCRIPTION
Replaced slider with spinbox for setting magnification value in A11y Zoom options. 
I've noticed that I could type `0` as a value even though the min value is set to `1`. It had no effect but it's still a bit weird. @jpnurmi, I had a look at your spinbox repo but can't see such bug reported.  