### PR TITLE
Use Yaru yellow

### DIFF
--- a/lib/view/pages/power/battery_section.dart
+++ b/lib/view/pages/power/battery_section.dart
@@ -43,7 +43,7 @@ class _BatterySectionState extends State<BatterySection> {
                   ? YaruColors.green
                   : model.percentage < 30.0
                       ? YaruColors.red
-                      : Colors.amber),
+                      : YaruColors.yellow),
         ),
         Padding(
           padding: const EdgeInsets.all(8.0),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,9 @@ dependencies:
   upower:
     git:
       url: https://github.com/canonical/upower.dart
-  yaru: ^0.2.0
+  yaru:
+    git:
+      url: https://github.com/ubuntu/yaru.dart
   yaru_icons: ^0.1.2
   yaru_widgets:
     git:


### PR DESCRIPTION
Use Yaru yellow instead of amber from Material colors.
I can't test this as I don't have a battery.

**Note:** I modified _yaru.dart_ package in `pubspec.yaml` to avoid creating a release just for this.