### PR TITLE
Dock section: re-align and add compact mode option

### DIFF
--- a/lib/view/pages/appearance/appearance_model.dart
+++ b/lib/view/pages/appearance/appearance_model.dart
@@ -112,6 +112,7 @@ class AppearanceModel extends ChangeNotifier {
     }
   }
 
+  // Currently this option is unstable and thus not exposed to the UI
   bool? get customThemeShrink =>
       _dashToDockSettings?.getValue(_customThemeShrink);
 

--- a/lib/view/pages/appearance/appearance_model.dart
+++ b/lib/view/pages/appearance/appearance_model.dart
@@ -29,42 +29,52 @@ class AppearanceModel extends ChangeNotifier {
 
   bool? get showTrash => _dashToDockSettings?.boolValue(_showTrashKey);
 
-  void setShowTrash(bool value) {
-    _dashToDockSettings?.setValue(_showTrashKey, value);
-    notifyListeners();
+  set showTrash(bool? value) {
+    if (value != null) {
+      _dashToDockSettings?.setValue(_showTrashKey, value);
+      notifyListeners();
+    }
   }
 
   bool? get alwaysShowDock => _dashToDockSettings?.boolValue(_dockFixedKey);
 
-  void setAlwaysShowDock(bool value) {
-    _dashToDockSettings?.setValue(_dockFixedKey, value);
-    notifyListeners();
+  set alwaysShowDock(bool? value) {
+    if (value != null) {
+      _dashToDockSettings?.setValue(_dockFixedKey, value);
+      notifyListeners();
+    }
   }
 
   bool? get extendDock => _dashToDockSettings?.boolValue(_extendHeightKey);
 
-  void setExtendDock(bool value) {
-    _dashToDockSettings?.setValue(_extendHeightKey, value);
-    notifyListeners();
+  set extendDock(bool? value) {
+    if (value != null) {
+      _dashToDockSettings?.setValue(_extendHeightKey, value);
+      notifyListeners();
+    }
   }
 
   bool? get appGlow => _dashToDockSettings?.boolValue(_backlitItemsKey);
 
-  void setAppGlow(bool value) {
-    _dashToDockSettings?.setValue(_backlitItemsKey, value);
-    notifyListeners();
+  set appGlow(bool? value) {
+    if (value != null) {
+      _dashToDockSettings?.setValue(_backlitItemsKey, value);
+      notifyListeners();
+    }
   }
 
   double? get maxIconSize =>
       _dashToDockSettings?.intValue(_dashMaxIconSizeKey)?.toDouble();
 
-  void setMaxIconSize(double value) {
-    var intValue = value.toInt();
-    if (intValue.isOdd) {
-      intValue -= 1;
+  set maxIconSize(double? value) {
+    if (value != null) {
+      var intValue = value.toInt();
+      if (intValue.isOdd) {
+        intValue -= 1;
+      }
+      _dashToDockSettings?.setValue(_dashMaxIconSizeKey, intValue);
+      notifyListeners();
     }
-    _dashToDockSettings?.setValue(_dashMaxIconSizeKey, intValue);
-    notifyListeners();
   }
 
   static const dockPositions = ['LEFT', 'RIGHT', 'BOTTOM'];
@@ -76,8 +86,10 @@ class AppearanceModel extends ChangeNotifier {
       dockPositions.contains(_realDockPosition) ? _realDockPosition : 'LEFT';
 
   set dockPosition(String? value) {
-    _dashToDockSettings!.setValue(_dockPositionKey, value!);
-    notifyListeners();
+    if (value != null) {
+      _dashToDockSettings!.setValue(_dockPositionKey, value);
+      notifyListeners();
+    }
   }
 
   static const clickActions = [
@@ -94,15 +106,19 @@ class AppearanceModel extends ChangeNotifier {
       : clickActions.first;
 
   set clickAction(String? value) {
-    _dashToDockSettings?.setValue(_clickActionKey, value!);
-    notifyListeners();
+    if (value != null) {
+      _dashToDockSettings?.setValue(_clickActionKey, value);
+      notifyListeners();
+    }
   }
 
   bool? get customThemeShrink =>
       _dashToDockSettings?.getValue(_customThemeShrink);
 
   set customThemeShrink(bool? value) {
-    _dashToDockSettings?.setValue(_customThemeShrink, value);
-    notifyListeners();
+    if (value != null) {
+      _dashToDockSettings?.setValue(_customThemeShrink, value);
+      notifyListeners();
+    }
   }
 }

--- a/lib/view/pages/appearance/appearance_model.dart
+++ b/lib/view/pages/appearance/appearance_model.dart
@@ -27,38 +27,36 @@ class AppearanceModel extends ChangeNotifier {
 
   // Dock section
 
-  bool get showTrash => _dashToDockSettings?.boolValue(_showTrashKey) ?? false;
+  bool? get showTrash => _dashToDockSettings?.boolValue(_showTrashKey);
 
   void setShowTrash(bool value) {
     _dashToDockSettings?.setValue(_showTrashKey, value);
     notifyListeners();
   }
 
-  bool get alwaysShowDock =>
-      _dashToDockSettings?.boolValue(_dockFixedKey) ?? true;
+  bool? get alwaysShowDock => _dashToDockSettings?.boolValue(_dockFixedKey);
 
   void setAlwaysShowDock(bool value) {
     _dashToDockSettings?.setValue(_dockFixedKey, value);
     notifyListeners();
   }
 
-  bool get extendDock =>
-      _dashToDockSettings?.boolValue(_extendHeightKey) ?? true;
+  bool? get extendDock => _dashToDockSettings?.boolValue(_extendHeightKey);
 
   void setExtendDock(bool value) {
     _dashToDockSettings?.setValue(_extendHeightKey, value);
     notifyListeners();
   }
 
-  bool get appGlow => _dashToDockSettings?.boolValue(_backlitItemsKey) ?? false;
+  bool? get appGlow => _dashToDockSettings?.boolValue(_backlitItemsKey);
 
   void setAppGlow(bool value) {
     _dashToDockSettings?.setValue(_backlitItemsKey, value);
     notifyListeners();
   }
 
-  double get maxIconSize =>
-      _dashToDockSettings?.intValue(_dashMaxIconSizeKey)?.toDouble() ?? 48.0;
+  double? get maxIconSize =>
+      _dashToDockSettings?.intValue(_dashMaxIconSizeKey)?.toDouble();
 
   void setMaxIconSize(double value) {
     var intValue = value.toInt();
@@ -100,10 +98,10 @@ class AppearanceModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool get customThemeShrink =>
-      _dashToDockSettings?.getValue(_customThemeShrink) ?? true;
+  bool? get customThemeShrink =>
+      _dashToDockSettings?.getValue(_customThemeShrink);
 
-  set customThemeShrink(bool value) {
+  set customThemeShrink(bool? value) {
     _dashToDockSettings?.setValue(_customThemeShrink, value);
     notifyListeners();
   }

--- a/lib/view/pages/appearance/appearance_model.dart
+++ b/lib/view/pages/appearance/appearance_model.dart
@@ -10,6 +10,7 @@ class AppearanceModel extends ChangeNotifier {
   static const _dashMaxIconSizeKey = 'dash-max-icon-size';
   static const _dockPositionKey = 'dock-position';
   static const _clickActionKey = 'click-action';
+  static const _customThemeShrink = 'custom-theme-shrink';
 
   AppearanceModel(SettingsService service)
       : _dashToDockSettings = service.lookup(schemaDashToDock) {
@@ -96,6 +97,14 @@ class AppearanceModel extends ChangeNotifier {
 
   set clickAction(String? value) {
     _dashToDockSettings?.setValue(_clickActionKey, value!);
+    notifyListeners();
+  }
+
+  bool get customThemeShrink =>
+      _dashToDockSettings?.getValue(_customThemeShrink) ?? true;
+
+  set customThemeShrink(bool value) {
+    _dashToDockSettings?.setValue(_customThemeShrink, value);
     notifyListeners();
   }
 }

--- a/lib/view/pages/appearance/dock_section.dart
+++ b/lib/view/pages/appearance/dock_section.dart
@@ -26,12 +26,12 @@ class DockSection extends StatelessWidget {
                     value: true,
                     groupValue: model.extendDock,
                     onChanged: (value) => model.setExtendDock(value!)),
-                enabled: true),
+                enabled: model.extendDock != null),
             Padding(
               padding: const EdgeInsets.all(assetPadding),
               child: SvgPicture.asset(
                 'assets/images/panel-mode.svg',
-                color: model.extendDock
+                color: (model.extendDock != null && model.extendDock == true)
                     ? Theme.of(context).primaryColor.withOpacity(0.1)
                     : Theme.of(context).backgroundColor,
                 colorBlendMode: BlendMode.color,
@@ -51,7 +51,7 @@ class DockSection extends StatelessWidget {
               padding: const EdgeInsets.all(assetPadding),
               child: SvgPicture.asset(
                 'assets/images/dock-mode.svg',
-                color: !model.extendDock
+                color: (model.extendDock != null && !model.extendDock!)
                     ? Theme.of(context).primaryColor.withOpacity(0.1)
                     : Theme.of(context).backgroundColor,
                 colorBlendMode: BlendMode.color,
@@ -61,7 +61,7 @@ class DockSection extends StatelessWidget {
             YaruSwitchRow(
                 trailingWidget: const Text('Compact look'),
                 actionDescription: 'Slims the dock to use less space.',
-                value: model.customThemeShrink,
+                value: model.customThemeShrink ?? false,
                 onChanged: (value) => model.customThemeShrink = value)
           ],
         ),
@@ -71,18 +71,21 @@ class DockSection extends StatelessWidget {
             Column(
               children: [
                 YaruSwitchRow(
+                  enabled: model.alwaysShowDock != null,
                   trailingWidget: const Text('Auto-hide the Dock'),
                   actionDescription: 'The dock hides when windows touch it.',
-                  value: !model.alwaysShowDock,
+                  value: model.alwaysShowDock != null &&
+                      model.alwaysShowDock == false,
                   onChanged: (value) => model.setAlwaysShowDock(!value),
                 ),
                 Padding(
                   padding: const EdgeInsets.all(assetPadding),
                   child: SvgPicture.asset(
                     'assets/images/auto-hide.svg',
-                    color: !model.alwaysShowDock
-                        ? Theme.of(context).primaryColor.withOpacity(0.1)
-                        : Theme.of(context).backgroundColor,
+                    color:
+                        (model.alwaysShowDock != null && !model.alwaysShowDock!)
+                            ? Theme.of(context).primaryColor.withOpacity(0.1)
+                            : Theme.of(context).backgroundColor,
                     colorBlendMode: BlendMode.color,
                     height: assetHeight,
                   ),
@@ -104,7 +107,7 @@ class DockSection extends StatelessWidget {
             ),
             YaruSliderRow(
               actionLabel: 'Icon Size',
-              value: model.maxIconSize,
+              value: model.maxIconSize ?? 48.0,
               min: 16,
               max: 64,
               defaultValue: 48,

--- a/lib/view/pages/appearance/dock_section.dart
+++ b/lib/view/pages/appearance/dock_section.dart
@@ -58,11 +58,6 @@ class DockSection extends StatelessWidget {
                 height: assetHeight,
               ),
             ),
-            YaruSwitchRow(
-                trailingWidget: const Text('Compact look'),
-                actionDescription: 'Slims the dock to use less space.',
-                value: model.customThemeShrink ?? false,
-                onChanged: (value) => model.customThemeShrink = value)
           ],
         ),
         YaruSection(

--- a/lib/view/pages/appearance/dock_section.dart
+++ b/lib/view/pages/appearance/dock_section.dart
@@ -6,108 +6,123 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 
 class DockSection extends StatelessWidget {
   const DockSection({Key? key}) : super(key: key);
+  static const assetHeight = 80.0;
+  static const assetPadding = 20.0;
 
   @override
   Widget build(BuildContext context) {
     final model = Provider.of<AppearanceModel>(context);
 
-    return YaruSection(
-      headline: 'Dock',
+    return Column(
       children: [
-        YaruSwitchRow(
-          trailingWidget: const Text('Show Trash'),
-          value: model.showTrash,
-          onChanged: (value) => model.setShowTrash(value),
-        ),
-        Column(
+        YaruSection(
+          headline: 'Dock shape',
           children: [
-            YaruSwitchRow(
-              trailingWidget: const Text('Auto-hide the Dock'),
-              value: !model.alwaysShowDock,
-              onChanged: (value) => model.setAlwaysShowDock(!value),
+            YaruRow(
+                trailingWidget: const Text('Panel'),
+                actionWidget: Radio<bool>(
+                    value: false,
+                    groupValue: model.extendDock,
+                    onChanged: (value) => model.setExtendDock(value!)),
+                enabled: true),
+            SvgPicture.asset(
+              'assets/images/panel-mode.svg',
+              color: !model.extendDock
+                  ? Theme.of(context).primaryColor.withOpacity(0.1)
+                  : Theme.of(context).backgroundColor,
+              colorBlendMode: BlendMode.color,
+              height: assetHeight,
             ),
-            Padding(
-              padding: const EdgeInsets.all(20.0),
-              child: SvgPicture.asset(
-                'assets/images/auto-hide.svg',
-                color: !model.alwaysShowDock
-                    ? Theme.of(context).primaryColor.withOpacity(0.1)
-                    : Theme.of(context).backgroundColor,
-                colorBlendMode: BlendMode.color,
-                height: 80,
-              ),
-            )
+            YaruRow(
+                trailingWidget: const Text('Dock'),
+                actionWidget: Radio<bool>(
+                    value: true,
+                    groupValue: model.extendDock,
+                    onChanged: (value) => model.setExtendDock(value!)),
+                enabled: true),
+            SvgPicture.asset(
+              'assets/images/dock-mode.svg',
+              color: model.extendDock
+                  ? Theme.of(context).primaryColor.withOpacity(0.1)
+                  : Theme.of(context).backgroundColor,
+              colorBlendMode: BlendMode.color,
+              height: assetHeight,
+            ),
+            YaruSwitchRow(
+                trailingWidget: const Text('Compact look'),
+                value: model.customThemeShrink,
+                onChanged: (value) => model.customThemeShrink = value)
           ],
         ),
-        Column(
+        YaruSection(
+          headline: 'Dock options',
           children: [
-            YaruSwitchRow(
-              trailingWidget: const Text('Extend Dock'),
-              value: model.extendDock,
-              onChanged: (value) => model.setExtendDock(value),
+            Column(
+              children: [
+                YaruSwitchRow(
+                  trailingWidget: const Text('Auto-hide the Dock'),
+                  value: !model.alwaysShowDock,
+                  onChanged: (value) => model.setAlwaysShowDock(!value),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(assetPadding),
+                  child: SvgPicture.asset(
+                    'assets/images/auto-hide.svg',
+                    color: !model.alwaysShowDock
+                        ? Theme.of(context).primaryColor.withOpacity(0.1)
+                        : Theme.of(context).backgroundColor,
+                    colorBlendMode: BlendMode.color,
+                    height: assetHeight,
+                  ),
+                )
+              ],
             ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: SvgPicture.asset(
-                'assets/images/panel-mode.svg',
-                color: model.extendDock
-                    ? Theme.of(context).primaryColor.withOpacity(0.1)
-                    : Theme.of(context).backgroundColor,
-                colorBlendMode: BlendMode.color,
-                height: 80,
+            YaruSwitchRow(
+              trailingWidget: const Text('Show Trash'),
+              value: model.showTrash,
+              onChanged: (value) => model.setShowTrash(value),
+            ),
+            YaruSwitchRow(
+              trailingWidget: const Text('Active App Glow'),
+              value: model.appGlow,
+              onChanged: (value) => model.setAppGlow(value),
+            ),
+            YaruSliderRow(
+              actionLabel: 'Icon Size',
+              value: model.maxIconSize,
+              min: 16,
+              max: 64,
+              defaultValue: 48,
+              onChanged: (value) => model.setMaxIconSize(value),
+            ),
+            YaruRow(
+              enabled: model.dockPosition != null,
+              trailingWidget: const Text('Dock Position'),
+              actionWidget: DropdownButton<String>(
+                onChanged: (value) => model.dockPosition = value,
+                value: model.dockPosition,
+                items: [
+                  for (var item in AppearanceModel.dockPositions)
+                    DropdownMenuItem(
+                        child: Text(item.toLowerCase()), value: item)
+                ],
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: SvgPicture.asset(
-                'assets/images/dock-mode.svg',
-                color: !model.extendDock
-                    ? Theme.of(context).primaryColor.withOpacity(0.1)
-                    : Theme.of(context).backgroundColor,
-                colorBlendMode: BlendMode.color,
-                height: 80,
+            YaruRow(
+              enabled: model.clickAction != null,
+              trailingWidget: const Text('Click Action'),
+              actionWidget: DropdownButton<String>(
+                onChanged: (value) => model.clickAction = value,
+                value: model.clickAction,
+                items: [
+                  for (var item in AppearanceModel.clickActions)
+                    DropdownMenuItem(
+                        child: Text(item.toLowerCase().replaceAll('-', ' ')),
+                        value: item)
+                ],
               ),
             ),
           ],
-        ),
-        YaruSwitchRow(
-          trailingWidget: const Text('Active App Glow'),
-          value: model.appGlow,
-          onChanged: (value) => model.setAppGlow(value),
-        ),
-        YaruSliderRow(
-          actionLabel: 'Icon Size',
-          value: model.maxIconSize,
-          min: 16,
-          max: 64,
-          defaultValue: 48,
-          onChanged: (value) => model.setMaxIconSize(value),
-        ),
-        YaruRow(
-          enabled: model.dockPosition != null,
-          trailingWidget: const Text('Dock Position'),
-          actionWidget: DropdownButton<String>(
-            onChanged: (value) => model.dockPosition = value,
-            value: model.dockPosition,
-            items: [
-              for (var item in AppearanceModel.dockPositions)
-                DropdownMenuItem(child: Text(item.toLowerCase()), value: item)
-            ],
-          ),
-        ),
-        YaruRow(
-          enabled: model.clickAction != null,
-          trailingWidget: const Text('Click Action'),
-          actionWidget: DropdownButton<String>(
-            onChanged: (value) => model.clickAction = value,
-            value: model.clickAction,
-            items: [
-              for (var item in AppearanceModel.clickActions)
-                DropdownMenuItem(
-                    child: Text(item.toLowerCase().replaceAll('-', ' ')),
-                    value: item)
-            ],
-          ),
         ),
       ],
     );

--- a/lib/view/pages/appearance/dock_section.dart
+++ b/lib/view/pages/appearance/dock_section.dart
@@ -25,7 +25,7 @@ class DockSection extends StatelessWidget {
                 actionWidget: Radio<bool>(
                     value: true,
                     groupValue: model.extendDock,
-                    onChanged: (value) => model.setExtendDock(value!)),
+                    onChanged: (value) => model.extendDock = value),
                 enabled: model.extendDock != null),
             Padding(
               padding: const EdgeInsets.all(assetPadding),
@@ -45,7 +45,7 @@ class DockSection extends StatelessWidget {
                 actionWidget: Radio<bool>(
                     value: false,
                     groupValue: model.extendDock,
-                    onChanged: (value) => model.setExtendDock(value!)),
+                    onChanged: (value) => model.extendDock = value!),
                 enabled: true),
             Padding(
               padding: const EdgeInsets.all(assetPadding),
@@ -76,7 +76,7 @@ class DockSection extends StatelessWidget {
                   actionDescription: 'The dock hides when windows touch it.',
                   value: model.alwaysShowDock != null &&
                       model.alwaysShowDock == false,
-                  onChanged: (value) => model.setAlwaysShowDock(!value),
+                  onChanged: (value) => model.alwaysShowDock = !value,
                 ),
                 Padding(
                   padding: const EdgeInsets.all(assetPadding),
@@ -96,14 +96,14 @@ class DockSection extends StatelessWidget {
               trailingWidget: const Text('Show Trash'),
               actionDescription: 'Show the trash on the dock',
               value: model.showTrash,
-              onChanged: (value) => model.setShowTrash(value),
+              onChanged: (value) => model.showTrash = value,
             ),
             YaruSwitchRow(
               trailingWidget: const Text('Active App Glow'),
               actionDescription:
                   'Colors active app icons in their primary accent color.',
               value: model.appGlow,
-              onChanged: (value) => model.setAppGlow(value),
+              onChanged: (value) => model.appGlow = value,
             ),
             YaruSliderRow(
               actionLabel: 'Icon Size',
@@ -111,7 +111,7 @@ class DockSection extends StatelessWidget {
               min: 16,
               max: 64,
               defaultValue: 48,
-              onChanged: (value) => model.setMaxIconSize(value),
+              onChanged: (value) => model.maxIconSize = value,
             ),
             YaruRow(
               enabled: model.dockPosition != null,

--- a/lib/view/pages/appearance/dock_section.dart
+++ b/lib/view/pages/appearance/dock_section.dart
@@ -16,40 +16,51 @@ class DockSection extends StatelessWidget {
     return Column(
       children: [
         YaruSection(
-          headline: 'Dock shape',
+          headline: 'Dock appearance',
           children: [
             YaruRow(
-                trailingWidget: const Text('Panel'),
-                actionWidget: Radio<bool>(
-                    value: false,
-                    groupValue: model.extendDock,
-                    onChanged: (value) => model.setExtendDock(value!)),
-                enabled: true),
-            SvgPicture.asset(
-              'assets/images/panel-mode.svg',
-              color: !model.extendDock
-                  ? Theme.of(context).primaryColor.withOpacity(0.1)
-                  : Theme.of(context).backgroundColor,
-              colorBlendMode: BlendMode.color,
-              height: assetHeight,
-            ),
-            YaruRow(
-                trailingWidget: const Text('Dock'),
+                trailingWidget: const Text('Panel mode'),
+                description:
+                    'Extends the height of the dock to become a panel.',
                 actionWidget: Radio<bool>(
                     value: true,
                     groupValue: model.extendDock,
                     onChanged: (value) => model.setExtendDock(value!)),
                 enabled: true),
-            SvgPicture.asset(
-              'assets/images/dock-mode.svg',
-              color: model.extendDock
-                  ? Theme.of(context).primaryColor.withOpacity(0.1)
-                  : Theme.of(context).backgroundColor,
-              colorBlendMode: BlendMode.color,
-              height: assetHeight,
+            Padding(
+              padding: const EdgeInsets.all(assetPadding),
+              child: SvgPicture.asset(
+                'assets/images/panel-mode.svg',
+                color: model.extendDock
+                    ? Theme.of(context).primaryColor.withOpacity(0.1)
+                    : Theme.of(context).backgroundColor,
+                colorBlendMode: BlendMode.color,
+                height: assetHeight,
+              ),
+            ),
+            YaruRow(
+                trailingWidget: const Text('Dock mode'),
+                description:
+                    'Displays the dock in a centered, free-floating mode.',
+                actionWidget: Radio<bool>(
+                    value: false,
+                    groupValue: model.extendDock,
+                    onChanged: (value) => model.setExtendDock(value!)),
+                enabled: true),
+            Padding(
+              padding: const EdgeInsets.all(assetPadding),
+              child: SvgPicture.asset(
+                'assets/images/dock-mode.svg',
+                color: !model.extendDock
+                    ? Theme.of(context).primaryColor.withOpacity(0.1)
+                    : Theme.of(context).backgroundColor,
+                colorBlendMode: BlendMode.color,
+                height: assetHeight,
+              ),
             ),
             YaruSwitchRow(
                 trailingWidget: const Text('Compact look'),
+                actionDescription: 'Slims the dock to use less space.',
                 value: model.customThemeShrink,
                 onChanged: (value) => model.customThemeShrink = value)
           ],
@@ -61,6 +72,7 @@ class DockSection extends StatelessWidget {
               children: [
                 YaruSwitchRow(
                   trailingWidget: const Text('Auto-hide the Dock'),
+                  actionDescription: 'The dock hides when windows touch it.',
                   value: !model.alwaysShowDock,
                   onChanged: (value) => model.setAlwaysShowDock(!value),
                 ),
@@ -79,11 +91,14 @@ class DockSection extends StatelessWidget {
             ),
             YaruSwitchRow(
               trailingWidget: const Text('Show Trash'),
+              actionDescription: 'Show the trash on the dock',
               value: model.showTrash,
               onChanged: (value) => model.setShowTrash(value),
             ),
             YaruSwitchRow(
               trailingWidget: const Text('Active App Glow'),
+              actionDescription:
+                  'Colors active app icons in their primary accent color.',
               value: model.appGlow,
               onChanged: (value) => model.setAppGlow(value),
             ),
@@ -110,6 +125,8 @@ class DockSection extends StatelessWidget {
             ),
             YaruRow(
               enabled: model.clickAction != null,
+              description:
+                  'Defines what happens when you click on active app icons.',
               trailingWidget: const Text('Click Action'),
               actionWidget: DropdownButton<String>(
                 onChanged: (value) => model.clickAction = value,

--- a/lib/view/pages/multitasking/multi_tasking_model.dart
+++ b/lib/view/pages/multitasking/multi_tasking_model.dart
@@ -34,49 +34,61 @@ class MultiTaskingModel extends SafeChangeNotifier {
     super.dispose();
   }
 
-  bool get enableHotCorners =>
-      _multiTaskingSettings!.boolValue(_hotCornersKey) ?? false;
+  bool? get enableHotCorners =>
+      _multiTaskingSettings?.boolValue(_hotCornersKey);
 
-  set enableHotCorners(bool enableHotCorners) {
-    _multiTaskingSettings!.setValue(_hotCornersKey, enableHotCorners);
-    notifyListeners();
+  set enableHotCorners(bool? enableHotCorners) {
+    if (enableHotCorners != null) {
+      _multiTaskingSettings?.setValue(_hotCornersKey, enableHotCorners);
+      notifyListeners();
+    }
   }
 
-  bool get edgeTiling => _mutterSettings!.getValue(_edgeTilingKey) ?? false;
+  bool? get edgeTiling => _mutterSettings!.getValue(_edgeTilingKey) ?? false;
 
-  set edgeTiling(bool edgeTiling) {
-    _mutterSettings!.setValue(_edgeTilingKey, edgeTiling);
-    notifyListeners();
+  set edgeTiling(bool? edgeTiling) {
+    if (edgeTiling != null) {
+      _mutterSettings?.setValue(_edgeTilingKey, edgeTiling);
+      notifyListeners();
+    }
   }
 
-  bool get workSpaceOnlyOnPrimary =>
-      _mutterSettings!.getValue(_workspacesOnlyOnPrimaryKey) ?? false;
+  bool? get workSpaceOnlyOnPrimary =>
+      _mutterSettings?.getValue(_workspacesOnlyOnPrimaryKey);
 
-  set workSpaceOnlyOnPrimary(bool value) {
-    _mutterSettings!.setValue(_workspacesOnlyOnPrimaryKey, value);
-    notifyListeners();
+  set workSpaceOnlyOnPrimary(bool? value) {
+    if (value != null) {
+      _mutterSettings?.setValue(_workspacesOnlyOnPrimaryKey, value);
+      notifyListeners();
+    }
   }
 
-  bool get dynamicWorkspaces =>
-      _mutterSettings!.getValue(_dynamicWorkspacesKey) ?? false;
+  bool? get dynamicWorkspaces =>
+      _mutterSettings?.getValue(_dynamicWorkspacesKey);
 
-  set dynamicWorkspaces(bool value) {
-    _mutterSettings!.setValue(_dynamicWorkspacesKey, value);
-    notifyListeners();
+  set dynamicWorkspaces(bool? value) {
+    if (value != null) {
+      _mutterSettings?.setValue(_dynamicWorkspacesKey, value);
+      notifyListeners();
+    }
   }
 
-  int get numWorkspaces => _wmSettings!.getValue(_numWorkspacesKey) ?? 0;
+  int? get numWorkspaces => _wmSettings!.getValue(_numWorkspacesKey);
 
-  set numWorkspaces(int value) {
-    _wmSettings!.setValue(_numWorkspacesKey, value);
-    notifyListeners();
+  set numWorkspaces(int? value) {
+    if (value != null && value > 0) {
+      _wmSettings?.setValue(_numWorkspacesKey, value);
+      notifyListeners();
+    }
   }
 
-  bool get currentWorkspaceOnly =>
-      _appSwitchSettings!.getValue(_currentWorkspaceOnlyKey) ?? false;
+  bool? get currentWorkspaceOnly =>
+      _appSwitchSettings?.getValue(_currentWorkspaceOnlyKey);
 
-  set currentWorkspaceOnly(bool value) {
-    _appSwitchSettings!.setValue(_currentWorkspaceOnlyKey, value);
-    notifyListeners();
+  set currentWorkspaceOnly(bool? value) {
+    if (value != null) {
+      _appSwitchSettings?.setValue(_currentWorkspaceOnlyKey, value);
+      notifyListeners();
+    }
   }
 }

--- a/lib/view/pages/multitasking/multi_tasking_page.dart
+++ b/lib/view/pages/multitasking/multi_tasking_page.dart
@@ -107,29 +107,44 @@ class MultiTaskingPage extends StatelessWidget {
               ))
         ]),
         YaruSection(headline: 'Multi-Monitor', children: [
-          YaruSwitchRow(
-            trailingWidget: const Text('Workspaces on primary display only'),
-            value: model.workSpaceOnlyOnPrimary,
-            onChanged: (value) => model.workSpaceOnlyOnPrimary = value,
-          ),
-          Padding(
-            padding: const EdgeInsets.all(10.0),
-            child: SvgPicture.asset(
-              'assets/images/workspaces-primary-display.svg',
-              color: model.workSpaceOnlyOnPrimary != null &&
-                      model.workSpaceOnlyOnPrimary == true
-                  ? Theme.of(context).primaryColor.withOpacity(0.1)
-                  : Theme.of(context).backgroundColor,
-              colorBlendMode: BlendMode.color,
-              height: 60,
-            ),
-          ),
+          YaruRow(
+              trailingWidget: const Text('Workspaces span all displays'),
+              description:
+                  'All displays are included in one workspace and follow when you switch workspaces.',
+              actionWidget: Radio(
+                  value: false,
+                  groupValue: model.workSpaceOnlyOnPrimary,
+                  onChanged: (bool? value) =>
+                      model.workSpaceOnlyOnPrimary = value),
+              enabled: model.workSpaceOnlyOnPrimary != null),
           Padding(
             padding: const EdgeInsets.all(10.0),
             child: SvgPicture.asset(
               'assets/images/workspaces-span-displays.svg',
               color: !(model.workSpaceOnlyOnPrimary != null &&
                       model.workSpaceOnlyOnPrimary == true)
+                  ? Theme.of(context).primaryColor.withOpacity(0.1)
+                  : Theme.of(context).backgroundColor,
+              colorBlendMode: BlendMode.color,
+              height: 60,
+            ),
+          ),
+          YaruRow(
+              trailingWidget: const Text('Workspaces only on primary display'),
+              description:
+                  'Only your primary display is included in workspace switching.',
+              actionWidget: Radio(
+                  value: true,
+                  groupValue: model.workSpaceOnlyOnPrimary,
+                  onChanged: (bool? value) =>
+                      model.workSpaceOnlyOnPrimary = value),
+              enabled: model.workSpaceOnlyOnPrimary != null),
+          Padding(
+            padding: const EdgeInsets.all(10.0),
+            child: SvgPicture.asset(
+              'assets/images/workspaces-primary-display.svg',
+              color: !(model.workSpaceOnlyOnPrimary != null &&
+                      model.workSpaceOnlyOnPrimary == false)
                   ? Theme.of(context).primaryColor.withOpacity(0.1)
                   : Theme.of(context).backgroundColor,
               colorBlendMode: BlendMode.color,

--- a/lib/view/pages/multitasking/multi_tasking_page.dart
+++ b/lib/view/pages/multitasking/multi_tasking_page.dart
@@ -36,7 +36,8 @@ class MultiTaskingPage extends StatelessWidget {
                 padding: const EdgeInsets.all(20.0),
                 child: SvgPicture.asset(
                   'assets/images/hot-corner.svg',
-                  color: model.enableHotCorners
+                  color: (model.enableHotCorners != null &&
+                          model.enableHotCorners == true)
                       ? Theme.of(context).primaryColor.withOpacity(0.1)
                       : Theme.of(context).backgroundColor,
                   colorBlendMode: BlendMode.color,
@@ -58,7 +59,7 @@ class MultiTaskingPage extends StatelessWidget {
                 padding: const EdgeInsets.all(20.0),
                 child: SvgPicture.asset(
                   'assets/images/active-screen-edges.svg',
-                  color: model.edgeTiling
+                  color: model.edgeTiling != null && model.edgeTiling == true
                       ? Theme.of(context).primaryColor.withOpacity(0.1)
                       : Theme.of(context).backgroundColor,
                   colorBlendMode: BlendMode.color,
@@ -69,33 +70,38 @@ class MultiTaskingPage extends StatelessWidget {
           )
         ]),
         YaruSection(headline: 'Workspaces', children: [
-          RadioListTile(
+          RadioListTile<bool>(
             shape:
                 RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
             title: const Text('Dynamic Workspaces'),
             value: true,
             groupValue: model.dynamicWorkspaces,
-            onChanged: (bool? value) => model.dynamicWorkspaces = value!,
+            onChanged: (value) => model.dynamicWorkspaces = value,
           ),
-          RadioListTile(
+          RadioListTile<bool>(
             shape:
                 RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
             title: const Text('Fixed number of workspaces'),
             value: false,
             groupValue: model.dynamicWorkspaces,
-            onChanged: (bool? value) => model.dynamicWorkspaces = value!,
+            onChanged: (value) => model.dynamicWorkspaces = value!,
           ),
           YaruRow(
-              enabled: !model.dynamicWorkspaces,
+              enabled: model.dynamicWorkspaces != null &&
+                  model.dynamicWorkspaces == false,
               trailingWidget: const Text('Number of workspaces'),
               actionWidget: SizedBox(
                 height: 40,
                 width: 150,
                 child: SpinBox(
+                  min: 1,
                   decoration:
                       const InputDecoration(border: UnderlineInputBorder()),
-                  enabled: !model.dynamicWorkspaces,
-                  value: model.numWorkspaces.toDouble(),
+                  enabled: model.dynamicWorkspaces != null &&
+                      model.dynamicWorkspaces == false,
+                  value: model.numWorkspaces != null
+                      ? model.numWorkspaces!.toDouble()
+                      : 0,
                   onChanged: (value) => model.numWorkspaces = value.toInt(),
                 ),
               ))
@@ -110,7 +116,8 @@ class MultiTaskingPage extends StatelessWidget {
             padding: const EdgeInsets.all(10.0),
             child: SvgPicture.asset(
               'assets/images/workspaces-primary-display.svg',
-              color: model.workSpaceOnlyOnPrimary
+              color: model.workSpaceOnlyOnPrimary != null &&
+                      model.workSpaceOnlyOnPrimary == true
                   ? Theme.of(context).primaryColor.withOpacity(0.1)
                   : Theme.of(context).backgroundColor,
               colorBlendMode: BlendMode.color,
@@ -121,7 +128,8 @@ class MultiTaskingPage extends StatelessWidget {
             padding: const EdgeInsets.all(10.0),
             child: SvgPicture.asset(
               'assets/images/workspaces-span-displays.svg',
-              color: !model.workSpaceOnlyOnPrimary
+              color: !(model.workSpaceOnlyOnPrimary != null &&
+                      model.workSpaceOnlyOnPrimary == true)
                   ? Theme.of(context).primaryColor.withOpacity(0.1)
                   : Theme.of(context).backgroundColor,
               colorBlendMode: BlendMode.color,


### PR DESCRIPTION
multi tasking page:

- added more descriptions
- use radios when there are two assets available for a value 
- disable UI elements when the getters are returning null
- only setting values if they are not null

![grafik](https://user-images.githubusercontent.com/15329494/148654779-6658635c-b41d-43c6-966d-a6422d342b86.png)

dock section:

- added more descriptions
- use radios when there are two assets available for a value 
- disable UI elements when the getters are returning null
- only setting values if they are not null
- re-arranged the dock section in two instead of one section

![grafik](https://user-images.githubusercontent.com/15329494/148655937-42068208-8a2c-4ad2-b085-f75325a545cf.png)
