### PR TITLE
Make getters in Mouse & Touchpad model nullable

### DIFF
--- a/lib/view/pages/mouse_and_touchpad/general_section.dart
+++ b/lib/view/pages/mouse_and_touchpad/general_section.dart
@@ -19,7 +19,9 @@ class GeneralSection extends StatelessWidget {
           labels: const ['Left', 'Right'],
           actionDescription:
               'Sets the order of physical buttons on mice and touchpads',
-          selectedValues: [!model.leftHanded, model.leftHanded],
+          selectedValues: model.leftHanded != null
+              ? [!model.leftHanded!, model.leftHanded!]
+              : null,
           onPressed: (index) => model.setLeftHanded(index == 1),
         ),
       ],

--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
@@ -33,8 +33,7 @@ class MouseAndTouchpadModel extends ChangeNotifier {
 
   // Global section
 
-  bool get leftHanded =>
-      _peripheralsMouseSettings?.boolValue(_leftHanded) ?? false;
+  bool? get leftHanded => _peripheralsMouseSettings?.boolValue(_leftHanded);
 
   void setLeftHanded(bool value) {
     _peripheralsMouseSettings?.setValue(_leftHanded, value);

--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
@@ -42,16 +42,16 @@ class MouseAndTouchpadModel extends ChangeNotifier {
 
   // Mouse section
 
-  double get mouseSpeed =>
-      _peripheralsMouseSettings?.doubleValue(_mouseSpeedKey) ?? 0.0;
+  double? get mouseSpeed =>
+      _peripheralsMouseSettings?.doubleValue(_mouseSpeedKey);
 
   void setMouseSpeed(double value) {
     _peripheralsMouseSettings?.setValue(_mouseSpeedKey, value);
     notifyListeners();
   }
 
-  bool get mouseNaturalScroll =>
-      _peripheralsMouseSettings?.boolValue(_mouseNaturalScrollKey) ?? false;
+  bool? get mouseNaturalScroll =>
+      _peripheralsMouseSettings?.boolValue(_mouseNaturalScrollKey);
 
   void setMouseNaturalScroll(bool value) {
     _peripheralsMouseSettings?.setValue(_mouseNaturalScrollKey, value);

--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
@@ -60,51 +60,48 @@ class MouseAndTouchpadModel extends ChangeNotifier {
 
   // Touchpad section
 
-  double get touchpadSpeed =>
-      _peripheralsTouchpadSettings?.doubleValue(_touchpadSpeedKey) ?? 0.0;
+  double? get touchpadSpeed =>
+      _peripheralsTouchpadSettings?.doubleValue(_touchpadSpeedKey);
 
   void setTouchpadSpeed(double value) {
     _peripheralsTouchpadSettings?.setValue(_touchpadSpeedKey, value);
     notifyListeners();
   }
 
-  bool get touchpadNaturalScroll =>
-      _peripheralsTouchpadSettings?.boolValue(_touchpadNaturalScrollKey) ??
-      true;
+  bool? get touchpadNaturalScroll =>
+      _peripheralsTouchpadSettings?.boolValue(_touchpadNaturalScrollKey);
 
   void setTouchpadNaturalScroll(bool value) {
     _peripheralsTouchpadSettings?.setValue(_touchpadNaturalScrollKey, value);
     notifyListeners();
   }
 
-  bool get touchpadTapToClick =>
-      _peripheralsTouchpadSettings?.boolValue(_touchpadTapToClickKey) ?? true;
+  bool? get touchpadTapToClick =>
+      _peripheralsTouchpadSettings?.boolValue(_touchpadTapToClickKey);
 
   void setTouchpadTapToClick(bool value) {
     _peripheralsTouchpadSettings?.setValue(_touchpadTapToClickKey, value);
     notifyListeners();
   }
 
-  bool get touchpadDisableWhileTyping =>
-      _peripheralsTouchpadSettings?.boolValue(_touchpadDisableWhileTyping) ??
-      false;
+  bool? get touchpadDisableWhileTyping =>
+      _peripheralsTouchpadSettings?.boolValue(_touchpadDisableWhileTyping);
 
   void setTouchpadDisableWhileTyping(bool value) {
     _peripheralsTouchpadSettings?.setValue(_touchpadDisableWhileTyping, value);
     notifyListeners();
   }
 
-  bool get twoFingerScrolling =>
-      _peripheralsTouchpadSettings?.boolValue(_touchpadTwoFingerScrolling) ??
-      true;
+  bool? get twoFingerScrolling =>
+      _peripheralsTouchpadSettings?.boolValue(_touchpadTwoFingerScrolling);
 
   void setTwoFingerScrolling(bool value) {
     _peripheralsTouchpadSettings?.setValue(_touchpadTwoFingerScrolling, value);
     notifyListeners();
   }
 
-  bool get edgeScrolling =>
-      _peripheralsTouchpadSettings?.boolValue(_touchpadEdgeScrolling) ?? false;
+  bool? get edgeScrolling =>
+      _peripheralsTouchpadSettings?.boolValue(_touchpadEdgeScrolling);
 
   void setEdgeScrolling(bool value) {
     _peripheralsTouchpadSettings?.setValue(_touchpadEdgeScrolling, value);

--- a/lib/view/pages/mouse_and_touchpad/mouse_section.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_section.dart
@@ -26,7 +26,7 @@ class MouseSection extends StatelessWidget {
           trailingWidget: const Text('Natural Scrolling'),
           actionDescription: 'Scrolling moves the content, not the view',
           value: model.mouseNaturalScroll,
-          onChanged: (value) => model.setMouseNaturalScroll(value),
+          onChanged: model.setMouseNaturalScroll,
         ),
       ],
     );


### PR DESCRIPTION
When a schema doesn't exist we get null and display disabled widget.
Example:
![Screenshot from 2022-01-08 16-50-09](https://user-images.githubusercontent.com/1629120/148652579-aab156a2-39ef-4fd5-9b22-771c6081a6ca.png)

