### PR TITLE
Singleton rework

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:bluez/bluez.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:nm/nm.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/l10n/l10n.dart';
@@ -23,52 +24,24 @@ void main() async {
 
   final networkManagerClient = NetworkManagerClient();
   await networkManagerClient.connect();
+  final getIt = GetIt.instance;
+  getIt.registerSingleton<SettingsService>(SettingsService());
+  getIt.registerSingleton<NetworkManagerClient>(networkManagerClient);
+  getIt.registerSingleton<ChangeNotifierProvider>(ChangeNotifierProvider(
+    create: (_) => AppTheme(themeSettings),
+  ));
+  getIt.registerSingleton<HostnameService>(HostnameService());
+  getIt.registerSingleton<PowerProfileService>(PowerProfileService());
+  getIt.registerSingleton<BluetoothService>(BluetoothService());
+  getIt.registerSingleton<PowerSettingsService>(PowerSettingsService());
 
+  getIt.registerSingleton<UDisksClient>(UDisksClient());
+  getIt.registerSingleton<UPowerClient>(UPowerClient());
+  getIt.registerSingleton<BlueZClient>(BlueZClient());
+  getIt.registerSingleton<InputSourceService>(InputSourceService());
+  getIt.registerSingleton<AppTheme>(AppTheme(themeSettings));
   runApp(
-    MultiProvider(
-      providers: [
-        ChangeNotifierProvider(
-          create: (_) => AppTheme(themeSettings),
-        ),
-        Provider<BluetoothService>(
-          create: (_) => BluetoothService(),
-          dispose: (_, service) => service.dispose(),
-        ),
-        Provider<HostnameService>(
-          create: (_) => HostnameService(),
-          dispose: (_, service) => service.dispose(),
-        ),
-        Provider<NetworkManagerClient>.value(value: networkManagerClient),
-        Provider<PowerProfileService>(
-          create: (_) => PowerProfileService(),
-          dispose: (_, service) => service.dispose(),
-        ),
-        Provider<PowerSettingsService>(
-          create: (_) => PowerSettingsService(),
-          dispose: (_, service) => service.dispose(),
-        ),
-        Provider<SettingsService>(
-          create: (_) => SettingsService(),
-          dispose: (_, service) => service.dispose(),
-        ),
-        Provider<UDisksClient>(
-          create: (_) => UDisksClient(),
-          dispose: (_, client) => client.close(),
-        ),
-        Provider<UPowerClient>(
-          create: (_) => UPowerClient(),
-          dispose: (_, client) => client.close(),
-        ),
-        Provider<BlueZClient>(
-          create: (_) => BlueZClient(),
-          dispose: (_, client) => client.close(),
-        ),
-        Provider<InputSourceService>(
-          create: (_) => InputSourceService(),
-        )
-      ],
-      child: const UbuntuSettingsApp(),
-    ),
+    const UbuntuSettingsApp(),
   );
 }
 
@@ -96,7 +69,7 @@ class UbuntuSettingsApp extends StatelessWidget {
       },
       theme: yaruLight,
       darkTheme: yaruDark,
-      themeMode: context.watch<AppTheme>().value,
+      themeMode: GetIt.instance.get<AppTheme>().value,
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
     );

--- a/lib/view/pages/accessibility/accessibility_page.dart
+++ b/lib/view/pages/accessibility/accessibility_page.dart
@@ -7,12 +7,13 @@ import 'package:settings/view/pages/accessibility/hearing_section.dart';
 import 'package:settings/view/pages/accessibility/pointing_and_clicking_section.dart';
 import 'package:settings/view/pages/accessibility/seeing_section.dart';
 import 'package:settings/view/pages/accessibility/typing_section.dart';
+import 'package:get_it/get_it.dart';
 
 class AccessibilityPage extends StatelessWidget {
   const AccessibilityPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
     return ChangeNotifierProvider<AccessibilityModel>(
       create: (_) => AccessibilityModel(service),
       child: const AccessibilityPage(),

--- a/lib/view/pages/accessibility/global_section.dart
+++ b/lib/view/pages/accessibility/global_section.dart
@@ -8,7 +8,7 @@ class GlobalSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSection(
       headline: 'Global',
       children: [

--- a/lib/view/pages/accessibility/hearing_section.dart
+++ b/lib/view/pages/accessibility/hearing_section.dart
@@ -23,7 +23,7 @@ class _VisualAlerts extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruExtraOptionRow(
       iconData: YaruIcons.settings,
       actionLabel: 'Visual Alerts',
@@ -46,7 +46,7 @@ class _VisualAlertsSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSimpleDialog(
       title: 'Visual Alerts',
       closeIconData: YaruIcons.window_close,

--- a/lib/view/pages/accessibility/pointing_and_clicking_section.dart
+++ b/lib/view/pages/accessibility/pointing_and_clicking_section.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/view/pages/accessibility/accessibility_model.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
-
 import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class PointingAndClickingSection extends StatelessWidget {
   const PointingAndClickingSection({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSection(
       headline: 'Pointing & Clicking',
       children: [
@@ -43,7 +42,7 @@ class _ClickAssist extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruRow(
       enabled: model.clickAssistAvailable,
       trailingWidget: const Text('Click Assist'),
@@ -77,7 +76,7 @@ class _ClickAssistSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSimpleDialog(
       title: 'Click Assist',
       closeIconData: YaruIcons.window_close,

--- a/lib/view/pages/accessibility/seeing_section.dart
+++ b/lib/view/pages/accessibility/seeing_section.dart
@@ -2,16 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/view/pages/accessibility/accessibility_model.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
-
 import 'package:yaru_icons/yaru_icons.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
 
 class SeeingSection extends StatelessWidget {
   const SeeingSection({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSection(
       headline: 'Seeing',
       children: [
@@ -63,7 +62,7 @@ class _CursorSize extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruRow(
       enabled: model.cursorSize != null,
       trailingWidget: const Text('Cursor Size'),
@@ -100,7 +99,7 @@ class _CursorSizeSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSimpleDialog(
       title: 'Cursor Size',
       closeIconData: YaruIcons.window_close,
@@ -205,7 +204,7 @@ class _MagnifierOptions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return Padding(
       padding: const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
       child: Column(
@@ -244,7 +243,7 @@ class _MagnifierPositionOptions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return Column(
       children: [
         _RadioRow(
@@ -366,7 +365,7 @@ class _CrosshairsOptions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
 
     return Padding(
       padding: const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
@@ -427,7 +426,7 @@ class _ColorEffectsOptions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
 
     return Padding(
       padding: const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),

--- a/lib/view/pages/accessibility/typing_section.dart
+++ b/lib/view/pages/accessibility/typing_section.dart
@@ -9,7 +9,7 @@ class TypingSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSection(
       headline: 'Typing',
       children: [
@@ -31,7 +31,7 @@ class _RepeatKeys extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruExtraOptionRow(
       iconData: YaruIcons.settings,
       actionLabel: 'Repeat Keys',
@@ -54,7 +54,7 @@ class _RepeatKeysSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSimpleDialog(
       title: 'Repeat Keys',
       closeIconData: YaruIcons.window_close,
@@ -87,7 +87,7 @@ class _CursorBlinking extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruExtraOptionRow(
       iconData: YaruIcons.settings,
       actionLabel: 'Cursor Blinking',
@@ -110,7 +110,7 @@ class _CursorBlinkingSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSimpleDialog(
       title: 'Cursor Blinking',
       closeIconData: YaruIcons.window_close,
@@ -134,7 +134,7 @@ class _TypingAssist extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
 
     return YaruRow(
       enabled: model.typingAssistAvailable,
@@ -169,7 +169,7 @@ class _TypingAssistSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return YaruSimpleDialog(
       title: 'Typing Assist',
       closeIconData: YaruIcons.window_close,
@@ -214,7 +214,7 @@ class _StickyKeysSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: Column(
@@ -242,7 +242,7 @@ class _SlowKeysSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: Column(
@@ -285,7 +285,7 @@ class _BounceKeysSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AccessibilityModel>(context);
+    final model = context.watch<AccessibilityModel>();
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: Column(

--- a/lib/view/pages/appearance/appearance_page.dart
+++ b/lib/view/pages/appearance/appearance_page.dart
@@ -1,17 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
-import 'package:settings/view/pages/appearance/appearance_model.dart';
 import 'package:settings/view/pages/appearance/dark_mode_section.dart';
+import 'package:settings/view/pages/appearance/dock_model.dart';
 import 'package:settings/view/pages/appearance/dock_section.dart';
 
 class AppearancePage extends StatelessWidget {
   const AppearancePage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
-    return ChangeNotifierProvider<AppearanceModel>(
-      create: (_) => AppearanceModel(service),
+    final service = GetIt.instance.get<SettingsService>();
+    return ChangeNotifierProvider<DockModel>(
+      create: (_) => DockModel(service),
       child: const AppearancePage(),
     );
   }

--- a/lib/view/pages/appearance/dark_mode_section.dart
+++ b/lib/view/pages/appearance/dark_mode_section.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:get_it/get_it.dart';
 import 'package:settings/view/app_theme.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -9,7 +9,7 @@ class DarkModeSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = context.watch<AppTheme>();
+    final theme = GetIt.instance.get<AppTheme>();
     return YaruSection(
       headline: 'Dark mode',
       children: [

--- a/lib/view/pages/appearance/dock_model.dart
+++ b/lib/view/pages/appearance/dock_model.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
-class AppearanceModel extends ChangeNotifier {
+class DockModel extends ChangeNotifier {
   static const _showTrashKey = 'show-trash';
   static const _dockFixedKey = 'dock-fixed';
   static const _extendHeightKey = 'extend-height';
@@ -11,7 +11,7 @@ class AppearanceModel extends ChangeNotifier {
   static const _dockPositionKey = 'dock-position';
   static const _clickActionKey = 'click-action';
 
-  AppearanceModel(SettingsService service)
+  DockModel(SettingsService service)
       : _dashToDockSettings = service.lookup(schemaDashToDock) {
     _dashToDockSettings?.addListener(notifyListeners);
   }
@@ -23,8 +23,6 @@ class AppearanceModel extends ChangeNotifier {
   }
 
   final Settings? _dashToDockSettings;
-
-  // Dock section
 
   bool? get showTrash => _dashToDockSettings?.boolValue(_showTrashKey);
 

--- a/lib/view/pages/appearance/dock_section.dart
+++ b/lib/view/pages/appearance/dock_section.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
-import 'package:settings/view/pages/appearance/appearance_model.dart';
+import 'package:settings/view/pages/appearance/dock_model.dart';
 import 'package:settings/view/selectable_svg_image.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -12,7 +12,7 @@ class DockSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AppearanceModel>(context);
+    final model = context.watch<DockModel>();
 
     return Column(
       children: [

--- a/lib/view/pages/bluetooth/bluetooth_page.dart
+++ b/lib/view/pages/bluetooth/bluetooth_page.dart
@@ -1,5 +1,6 @@
 import 'package:bluez/bluez.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/view/pages/bluetooth/bluetooth_device_row.dart';
 import 'package:settings/view/pages/bluetooth/bluetooth_model.dart';
@@ -10,7 +11,7 @@ class BluetoothPage extends StatefulWidget {
 
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => BluetoothModel(context.read<BlueZClient>()),
+      create: (_) => BluetoothModel(GetIt.instance.get<BlueZClient>()),
       child: const BluetoothPage(),
     );
   }

--- a/lib/view/pages/connections/connections_page.dart
+++ b/lib/view/pages/connections/connections_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:nm/nm.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/view/pages/connections/wifi_content.dart';
@@ -9,7 +10,7 @@ import 'models/wifi_model.dart';
 
 class ConnectionsPage extends StatefulWidget {
   static Widget create(BuildContext context) {
-    final service = Provider.of<NetworkManagerClient>(context, listen: false);
+    final service = GetIt.instance.get<NetworkManagerClient>();
     return ChangeNotifierProvider<WifiModel>(
       create: (_) => WifiModel(service),
       child: const ConnectionsPage(),

--- a/lib/view/pages/info/info_page.dart
+++ b/lib/view/pages/info/info_page.dart
@@ -1,5 +1,6 @@
 import 'package:filesize/filesize.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:open_file/open_file.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
@@ -18,8 +19,8 @@ class InfoPage extends StatefulWidget {
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider<InfoModel>(
       create: (_) => InfoModel(
-        hostnameService: context.read<HostnameService>(),
-        uDisksClient: context.read<UDisksClient>(),
+        hostnameService: GetIt.instance.get<HostnameService>(),
+        uDisksClient: GetIt.instance.get<UDisksClient>(),
       ),
       child: const InfoPage(),
     );
@@ -137,7 +138,7 @@ class _Computer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<InfoModel>(context);
+    final model = context.read<InfoModel>();
 
     return YaruSection(headline: 'Computer', children: [
       YaruRow(

--- a/lib/view/pages/keyboard/keyboard_settings_page.dart
+++ b/lib/view/pages/keyboard/keyboard_settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/input_source_service.dart';
 import 'package:settings/services/settings_service.dart';
@@ -15,10 +16,8 @@ class KeyboardSettingsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final settingsService =
-        Provider.of<SettingsService>(context, listen: false);
-    final inputSourceService =
-        Provider.of<InputSourceService>(context, listen: false);
+    final settingsService = GetIt.instance.get<SettingsService>();
+    final inputSourceService = GetIt.instance.get<InputSourceService>();
 
     return Column(
       children: [

--- a/lib/view/pages/keyboard/keyboard_shortcuts_page.dart
+++ b/lib/view/pages/keyboard/keyboard_shortcuts_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
@@ -11,7 +12,7 @@ class KeyboardShortcutsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
 
     return Column(
       children: [

--- a/lib/view/pages/mouse_and_touchpad/general_section.dart
+++ b/lib/view/pages/mouse_and_touchpad/general_section.dart
@@ -9,7 +9,7 @@ class GeneralSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<MouseAndTouchpadModel>(context);
+    final model = context.watch<MouseAndTouchpadModel>();
 
     return YaruSection(
       headline: 'General',

--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_page.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/mouse_and_touchpad/general_section.dart';
@@ -10,7 +11,7 @@ class MouseAndTouchpadPage extends StatelessWidget {
   const MouseAndTouchpadPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
     return ChangeNotifierProvider<MouseAndTouchpadModel>(
       create: (_) => MouseAndTouchpadModel(service),
       child: const MouseAndTouchpadPage(),

--- a/lib/view/pages/mouse_and_touchpad/mouse_section.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_section.dart
@@ -8,7 +8,7 @@ class MouseSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<MouseAndTouchpadModel>(context);
+    final model = context.watch<MouseAndTouchpadModel>();
 
     return YaruSection(
       headline: 'Mouse',

--- a/lib/view/pages/mouse_and_touchpad/touchpad_section.dart
+++ b/lib/view/pages/mouse_and_touchpad/touchpad_section.dart
@@ -8,7 +8,7 @@ class TouchpadSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<MouseAndTouchpadModel>(context);
+    final model = context.watch<MouseAndTouchpadModel>();
 
     return YaruSection(
       headline: 'Touchpad',

--- a/lib/view/pages/multitasking/multi_tasking_page.dart
+++ b/lib/view/pages/multitasking/multi_tasking_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/multitasking/multi_tasking_model.dart';
@@ -10,7 +11,7 @@ class MultiTaskingPage extends StatelessWidget {
   const MultiTaskingPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
     return ChangeNotifierProvider<MultiTaskingModel>(
       create: (_) => MultiTaskingModel(service),
       child: const MultiTaskingPage(),

--- a/lib/view/pages/notifications/app_notifications_section.dart
+++ b/lib/view/pages/notifications/app_notifications_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/notifications/notifications_model.dart';
@@ -9,7 +10,7 @@ class AppNotificationsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<NotificationsModel>(context);
+    final model = context.watch<NotificationsModel>();
 
     return YaruSection(
       headline: 'App notifications',
@@ -26,7 +27,7 @@ class AppNotificationsSettingRow extends StatelessWidget {
   const AppNotificationsSettingRow({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context, {required String appId}) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
     return ChangeNotifierProvider(
       create: (_) => AppNotificationsModel(appId, service),
       child: const AppNotificationsSettingRow(),
@@ -35,7 +36,7 @@ class AppNotificationsSettingRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<AppNotificationsModel>(context);
+    final model = context.watch<AppNotificationsModel>();
     return YaruSwitchRow(
       trailingWidget: Text(model.appId),
       value: model.enable,

--- a/lib/view/pages/notifications/global_notifications_section.dart
+++ b/lib/view/pages/notifications/global_notifications_section.dart
@@ -8,7 +8,7 @@ class GlobalNotificationsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<NotificationsModel>(context);
+    final model = context.watch<NotificationsModel>();
 
     return YaruSection(
       headline: 'Global',

--- a/lib/view/pages/notifications/notifications_page.dart
+++ b/lib/view/pages/notifications/notifications_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/notifications/app_notifications_section.dart';
@@ -9,7 +10,7 @@ class NotificationsPage extends StatelessWidget {
   const NotificationsPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
     return ChangeNotifierProvider<NotificationsModel>(
       create: (_) => NotificationsModel(service),
       child: const NotificationsPage(),

--- a/lib/view/pages/power/battery_section.dart
+++ b/lib/view/pages/power/battery_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/view/pages/power/battery_model.dart';
 import 'package:settings/view/pages/power/battery_widgets.dart';
@@ -26,7 +27,7 @@ class _BatterySectionState extends State<BatterySection> {
     super.initState();
 
     final model = context.read<BatteryModel>();
-    model.init(context.read<UPowerClient>());
+    model.init(GetIt.instance.get<UPowerClient>());
   }
 
   @override

--- a/lib/view/pages/power/power_profile_section.dart
+++ b/lib/view/pages/power/power_profile_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/power_profile_service.dart';
 import 'package:settings/view/pages/power/power_profile_model.dart';
@@ -9,7 +10,8 @@ class PowerProfileSection extends StatefulWidget {
 
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider<PowerProfileModel>(
-      create: (_) => PowerProfileModel(context.read<PowerProfileService>()),
+      create: (_) =>
+          PowerProfileModel(GetIt.instance.get<PowerProfileService>()),
       child: const PowerProfileSection(),
     );
   }

--- a/lib/view/pages/power/power_settings_section.dart
+++ b/lib/view/pages/power/power_settings_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:nm/nm.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/bluetooth_service.dart';
@@ -17,10 +18,10 @@ class PowerSettingsSection extends StatefulWidget {
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider<SuspendModel>(
       create: (_) => SuspendModel(
-        settings: context.read<SettingsService>(),
-        power: context.read<PowerSettingsService>(),
-        bluetooth: context.read<BluetoothService>(),
-        network: context.read<NetworkManagerClient>(),
+        settings: GetIt.instance.get<SettingsService>(),
+        power: GetIt.instance.get<PowerSettingsService>(),
+        bluetooth: GetIt.instance.get<BluetoothService>(),
+        network: GetIt.instance.get<NetworkManagerClient>(),
       ),
       child: const PowerSettingsSection(),
     );

--- a/lib/view/pages/power/suspend_section.dart
+++ b/lib/view/pages/power/suspend_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/power/suspend.dart';
@@ -11,7 +12,7 @@ class SuspendSection extends StatefulWidget {
   static Widget create(BuildContext context) {
     return ChangeNotifierProvider<SuspendModel>(
       create: (_) => SuspendModel(
-        context.read<SettingsService>(),
+        GetIt.instance.get<SettingsService>(),
       ),
       child: const SuspendSection(),
     );

--- a/lib/view/pages/removable_media/removable_media_page.dart
+++ b/lib/view/pages/removable_media/removable_media_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/removable_media/removable_media_model.dart';
@@ -8,7 +9,7 @@ class RemovableMediaPage extends StatelessWidget {
   const RemovableMediaPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
     return ChangeNotifierProvider<RemovableMediaModel>(
       create: (_) => RemovableMediaModel(service),
       child: const RemovableMediaPage(),
@@ -17,7 +18,7 @@ class RemovableMediaPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<RemovableMediaModel>(context);
+    final model = context.watch<RemovableMediaModel>();
 
     return YaruSection(headline: 'Removable Media', children: [
       SizedBox(

--- a/lib/view/pages/sound/sound_page.dart
+++ b/lib/view/pages/sound/sound_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/sound/sound_model.dart';
@@ -8,7 +9,7 @@ class SoundPage extends StatelessWidget {
   const SoundPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
     return ChangeNotifierProvider<SoundModel>(
       create: (_) => SoundModel(service),
       child: const SoundPage(),
@@ -17,7 +18,7 @@ class SoundPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<SoundModel>(context);
+    final model = context.watch<SoundModel>();
 
     return Column(
       children: [

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:filesystem_picker/filesystem_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/wallpaper/color_shading_option_row.dart';
@@ -13,7 +14,7 @@ class WallpaperPage extends StatelessWidget {
   const WallpaperPage({Key? key}) : super(key: key);
 
   static Widget create(BuildContext context) {
-    final service = Provider.of<SettingsService>(context, listen: false);
+    final service = GetIt.instance.get<SettingsService>();
     return ChangeNotifierProvider<WallpaperModel>(
       create: (_) => WallpaperModel(service),
       child: const WallpaperPage(),
@@ -22,7 +23,7 @@ class WallpaperPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<WallpaperModel>(context);
+    final model = context.watch<WallpaperModel>();
 
     return YaruSection(headline: 'Set your wallpaper', children: [
       YaruRow(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -305,6 +305,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  get_it:
+    dependency: "direct main"
+    description:
+      name: get_it
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.2.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   flutter_spinbox: ^0.7.0
   http: ^0.13.4
   xml: ^5.3.1
+  get_it: ^7.2.0
 
 dev_dependencies:
   build_runner: ^2.1.2
@@ -75,3 +76,4 @@ flutter:
     - assets/images/appearance/dock-mode/
     - assets/images/appearance/auto-hide-panel-mode/
     - assets/images/appearance/auto-hide-dock-mode/
+    - assets/rive/


### PR DESCRIPTION
- use get_it instead of provider for service singleton instantiation
- unify how to access model singletons to context.watch<>()
- rename AppearanceModel to DockModel because it only exists for the dock