### PR TITLE
AppearancePage: rename model to DockModel

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,8 @@ void main() async {
   runApp(
     MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (_) => LightTheme(yaruLight)),
+        ChangeNotifierProvider(create: (_) => DarkTheme(yaruDark)),
         ChangeNotifierProvider(
           create: (_) => AppTheme(themeSettings),
         ),
@@ -94,8 +96,8 @@ class UbuntuSettingsApp extends StatelessWidget {
           );
         },
       },
-      theme: yaruLight,
-      darkTheme: yaruDark,
+      theme: context.watch<LightTheme>().value,
+      darkTheme: context.watch<DarkTheme>().value,
       themeMode: context.watch<AppTheme>().value,
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/lib/view/app_theme.dart
+++ b/lib/view/app_theme.dart
@@ -25,3 +25,11 @@ class AppTheme extends ValueNotifier<ThemeMode> {
     super.dispose();
   }
 }
+
+class LightTheme extends ValueNotifier<ThemeData> {
+  LightTheme(ThemeData value) : super(value);
+}
+
+class DarkTheme extends ValueNotifier<ThemeData> {
+  DarkTheme(ThemeData value) : super(value);
+}

--- a/lib/view/pages/appearance/appearance_page.dart
+++ b/lib/view/pages/appearance/appearance_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/services/settings_service.dart';
-import 'package:settings/view/pages/appearance/appearance_model.dart';
+import 'package:settings/view/pages/appearance/dock_model.dart';
 import 'package:settings/view/pages/appearance/dark_mode_section.dart';
 import 'package:settings/view/pages/appearance/dock_section.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -11,8 +11,8 @@ class AppearancePage extends StatelessWidget {
 
   static Widget create(BuildContext context) {
     final service = Provider.of<SettingsService>(context, listen: false);
-    return ChangeNotifierProvider<AppearanceModel>(
-      create: (_) => AppearanceModel(service),
+    return ChangeNotifierProvider<DockModel>(
+      create: (_) => DockModel(service),
       child: const AppearancePage(),
     );
   }

--- a/lib/view/pages/appearance/dark_mode_section.dart
+++ b/lib/view/pages/appearance/dark_mode_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/view/app_theme.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -10,8 +11,10 @@ class DarkModeSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = context.watch<AppTheme>();
+    final lighTheme = context.watch<LightTheme>();
+    final darkTheme = context.watch<DarkTheme>();
     return YaruSection(
-      headline: 'Dark mode',
+      headline: 'Theme',
       children: [
         YaruSwitchRow(
             trailingWidget: Theme.of(context).brightness == Brightness.light
@@ -35,6 +38,40 @@ class DarkModeSection extends StatelessWidget {
                   ? Brightness.light
                   : Brightness.dark);
             }),
+        YaruRow(
+            trailingWidget: const Text('Change theme'),
+            actionWidget: Row(
+              children: [
+                YaruColorPickerButton(
+                    color: yaruLight.primaryColor,
+                    onPressed: () {
+                      lighTheme.value = yaruLight;
+                      darkTheme.value = yaruDark;
+                    }),
+                const SizedBox(
+                  width: 10,
+                ),
+                YaruColorPickerButton(
+                    color: yaruKubuntuLight.primaryColor,
+                    onPressed: () {
+                      lighTheme.value = yaruKubuntuLight;
+                      darkTheme.value = yaruKubuntuDark;
+                    }),
+                const SizedBox(
+                  width: 10,
+                ),
+                YaruColorPickerButton(
+                    color: yaruMateLight.primaryColor,
+                    onPressed: () {
+                      lighTheme.value = yaruMateLight;
+                      darkTheme.value = yaruMateDark;
+                    }),
+                const SizedBox(
+                  width: 10,
+                ),
+              ],
+            ),
+            enabled: true)
       ],
     );
   }

--- a/lib/view/pages/appearance/dock_model.dart
+++ b/lib/view/pages/appearance/dock_model.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 
-class AppearanceModel extends ChangeNotifier {
+class DockModel extends ChangeNotifier {
   static const _showTrashKey = 'show-trash';
   static const _dockFixedKey = 'dock-fixed';
   static const _extendHeightKey = 'extend-height';
@@ -11,7 +11,7 @@ class AppearanceModel extends ChangeNotifier {
   static const _dockPositionKey = 'dock-position';
   static const _clickActionKey = 'click-action';
 
-  AppearanceModel(SettingsService service)
+  DockModel(SettingsService service)
       : _dashToDockSettings = service.lookup(schemaDashToDock) {
     _dashToDockSettings?.addListener(notifyListeners);
   }

--- a/lib/view/pages/appearance/dock_section.dart
+++ b/lib/view/pages/appearance/dock_section.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
-import 'package:settings/view/pages/appearance/appearance_model.dart';
+import 'package:settings/view/pages/appearance/dock_model.dart';
 import 'package:settings/view/selectable_svg_image.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -12,7 +12,7 @@ class DockSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = context.watch<AppearanceModel>();
+    final model = context.watch<DockModel>();
 
     return Column(
       children: [

--- a/lib/view/pages/wallpaper/color_shading_option_row.dart
+++ b/lib/view/pages/wallpaper/color_shading_option_row.dart
@@ -46,7 +46,7 @@ class ColorShadingOptionRow extends StatelessWidget {
             ],
           ),
           const SizedBox(width: 8.0),
-          ColorPickerButton(
+          YaruColorPickerButton(
             color: fromHex(model.primaryColor),
             onPressed: () async {
               final colorBeforeDialog = model.primaryColor;
@@ -58,7 +58,7 @@ class ColorShadingOptionRow extends StatelessWidget {
           if (model.colorShadingType != ColorShadingType.solid)
             const SizedBox(width: 8.0),
           if (model.colorShadingType != ColorShadingType.solid)
-            ColorPickerButton(
+            YaruColorPickerButton(
                 color: fromHex(model.secondaryColor),
                 onPressed: () async {
                   final colorBeforeDialog = model.secondaryColor;
@@ -129,38 +129,6 @@ class ColorShadingOptionRow extends StatelessWidget {
       context,
       constraints:
           const BoxConstraints(minHeight: 480, minWidth: 300, maxWidth: 320),
-    );
-  }
-}
-
-class ColorPickerButton extends StatelessWidget {
-  const ColorPickerButton({
-    Key? key,
-    required this.color,
-    required this.onPressed,
-  }) : super(key: key);
-
-  final VoidCallback onPressed;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    const size = 40.0;
-    return SizedBox(
-      width: size,
-      height: size,
-      child: OutlinedButton(
-        style: OutlinedButton.styleFrom(padding: const EdgeInsets.all(0)),
-        onPressed: onPressed,
-        child: SizedBox(
-          width: size / 2,
-          height: size / 2,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(100), color: color),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -893,7 +893,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: b09a93cb6d7d7b6caf92c49aa6ea7f9ec4a1c04d
+      resolved-ref: f93fbba83b25265c9941ef59d5eb6bbeafc0eaa0
       url: "https://github.com/ubuntu/yaru_widgets.dart"
     source: git
     version: "1.0.0+1"


### PR DESCRIPTION
- also use YaruColorPickerButton
- this may give ideas what to actually do with the appearance page is it currently is almost only the "DockPage"

![grafik](https://user-images.githubusercontent.com/15329494/149216359-b2d92198-a8a7-49ab-8008-dce0c6bddad6.png)

This needs a change to the assets to not hardcode the orange
CC @Muqtxdir 