### PR TITLE
Don't allow selecting both scrolling types at the same time

### DIFF
--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart
@@ -96,6 +96,9 @@ class MouseAndTouchpadModel extends ChangeNotifier {
       _peripheralsTouchpadSettings?.boolValue(_touchpadTwoFingerScrolling);
 
   void setTwoFingerScrolling(bool value) {
+    if (value) {
+      setEdgeScrolling(false);
+    }
     _peripheralsTouchpadSettings?.setValue(_touchpadTwoFingerScrolling, value);
     notifyListeners();
   }
@@ -104,6 +107,9 @@ class MouseAndTouchpadModel extends ChangeNotifier {
       _peripheralsTouchpadSettings?.boolValue(_touchpadEdgeScrolling);
 
   void setEdgeScrolling(bool value) {
+    if (value) {
+      setTwoFingerScrolling(false);
+    }
     _peripheralsTouchpadSettings?.setValue(_touchpadEdgeScrolling, value);
     notifyListeners();
   }


### PR DESCRIPTION
Looks like we could select both: edge scrolling and 2-finger scrolling at the same time. This PR should fix this.

Before:
![before](https://user-images.githubusercontent.com/1629120/149555722-b25f83cb-3a1f-4897-8340-2aa66b1269dd.gif)

After:
![after](https://user-images.githubusercontent.com/1629120/149555750-3e5d1151-d822-468d-be9a-13ba5323066f.gif)

