### PR TITLE
Use updated yaru_widgets.dart

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,0 +1,1 @@
+const kDefaultWidth = 500.0;

--- a/lib/view/pages/accessibility/accessibility_page.dart
+++ b/lib/view/pages/accessibility/accessibility_page.dart
@@ -22,16 +22,14 @@ class AccessibilityPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return YaruPage(
-      child: Column(
-        children: const [
-          GlobalSection(),
-          SeeingSection(),
-          HearingSection(),
-          TypingSection(),
-          PointingAndClickingSection(),
-        ],
-      ),
+    return const YaruPage(
+      children: [
+        GlobalSection(),
+        SeeingSection(),
+        HearingSection(),
+        TypingSection(),
+        PointingAndClickingSection(),
+      ],
     );
   }
 }

--- a/lib/view/pages/accessibility/global_section.dart
+++ b/lib/view/pages/accessibility/global_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/accessibility/accessibility_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -10,6 +11,7 @@ class GlobalSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<AccessibilityModel>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Global',
       children: [
         YaruSwitchRow(

--- a/lib/view/pages/accessibility/hearing_section.dart
+++ b/lib/view/pages/accessibility/hearing_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/accessibility/accessibility_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -10,6 +11,7 @@ class HearingSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const YaruSection(
+      width: kDefaultWidth,
       headline: 'Hearing',
       children: [
         _VisualAlerts(),

--- a/lib/view/pages/accessibility/pointing_and_clicking_section.dart
+++ b/lib/view/pages/accessibility/pointing_and_clicking_section.dart
@@ -93,18 +93,16 @@ class _ClickAssistSettings extends StatelessWidget {
         ),
         Padding(
           padding: const EdgeInsets.only(left: 16.0),
-          child: SizedBox(
-            height: 56,
-            child: YaruSliderRow(
-              enabled: model.simulatedSecondaryClick ?? false,
-              actionLabel: 'Delay',
-              value: model.secondaryClickTime,
-              min: 0.5,
-              max: 3.0,
-              defaultValue: 1.2,
-              fractionDigits: 1,
-              onChanged: model.setSecondaryClickTime,
-            ),
+          child: YaruSliderRow(
+            width: 500,
+            enabled: model.simulatedSecondaryClick ?? false,
+            actionLabel: 'Delay',
+            value: model.secondaryClickTime,
+            min: 0.5,
+            max: 3.0,
+            defaultValue: 1.2,
+            fractionDigits: 1,
+            onChanged: model.setSecondaryClickTime,
           ),
         ),
         YaruSwitchRow(
@@ -116,10 +114,12 @@ class _ClickAssistSettings extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(left: 16.0),
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               SizedBox(
                 height: 56,
                 child: YaruSliderRow(
+                  width: 500,
                   enabled: model.dwellClick ?? false,
                   actionLabel: 'Delay',
                   value: model.dwellTime,
@@ -133,6 +133,7 @@ class _ClickAssistSettings extends StatelessWidget {
               SizedBox(
                 height: 56,
                 child: YaruSliderRow(
+                  width: 500,
                   enabled: model.dwellClick ?? false,
                   actionLabel: 'Motion thresshold',
                   value: model.dwellThreshold,

--- a/lib/view/pages/accessibility/pointing_and_clicking_section.dart
+++ b/lib/view/pages/accessibility/pointing_and_clicking_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/accessibility/accessibility_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -12,6 +13,7 @@ class PointingAndClickingSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<AccessibilityModel>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Pointing & Clicking',
       children: [
         YaruSwitchRow(

--- a/lib/view/pages/accessibility/pointing_and_clicking_section.dart
+++ b/lib/view/pages/accessibility/pointing_and_clicking_section.dart
@@ -94,7 +94,7 @@ class _ClickAssistSettings extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(left: 16.0),
           child: YaruSliderRow(
-            width: 500,
+            width: kDefaultWidth,
             enabled: model.simulatedSecondaryClick ?? false,
             actionLabel: 'Delay',
             value: model.secondaryClickTime,
@@ -119,7 +119,7 @@ class _ClickAssistSettings extends StatelessWidget {
               SizedBox(
                 height: 56,
                 child: YaruSliderRow(
-                  width: 500,
+                  width: kDefaultWidth,
                   enabled: model.dwellClick ?? false,
                   actionLabel: 'Delay',
                   value: model.dwellTime,
@@ -133,7 +133,7 @@ class _ClickAssistSettings extends StatelessWidget {
               SizedBox(
                 height: 56,
                 child: YaruSliderRow(
-                  width: 500,
+                  width: kDefaultWidth,
                   enabled: model.dwellClick ?? false,
                   actionLabel: 'Motion thresshold',
                   value: model.dwellThreshold,

--- a/lib/view/pages/accessibility/seeing_section.dart
+++ b/lib/view/pages/accessibility/seeing_section.dart
@@ -2,6 +2,7 @@ import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/utils.dart';
 import 'package:settings/view/pages/accessibility/accessibility_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -15,6 +16,7 @@ class SeeingSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<AccessibilityModel>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Seeing',
       children: [
         YaruSwitchRow(

--- a/lib/view/pages/accessibility/seeing_section.dart
+++ b/lib/view/pages/accessibility/seeing_section.dart
@@ -400,7 +400,7 @@ class _CrosshairsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
-            width: 500,
+            width: kDefaultWidth,
             actionLabel: 'Thickness',
             value: model.crossHairsThickness,
             min: 1,
@@ -413,7 +413,7 @@ class _CrosshairsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
-            width: 500,
+            width: kDefaultWidth,
             actionLabel: 'Length',
             value: model.crossHairsLength,
             min: 20,
@@ -510,7 +510,7 @@ class _ColorEffectsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
-            width: 500,
+            width: kDefaultWidth,
             actionLabel: 'Brightness',
             value: model.colorBrightness,
             min: -0.75,
@@ -523,7 +523,7 @@ class _ColorEffectsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
-            width: 500,
+            width: kDefaultWidth,
             actionLabel: 'Contrast',
             value: model.colorContrast,
             min: -0.75,
@@ -536,7 +536,7 @@ class _ColorEffectsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
-            width: 500,
+            width: kDefaultWidth,
             actionLabel: 'Saturation',
             value: model.colorSaturation,
             min: 0,

--- a/lib/view/pages/accessibility/seeing_section.dart
+++ b/lib/view/pages/accessibility/seeing_section.dart
@@ -400,6 +400,7 @@ class _CrosshairsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
+            width: 500,
             actionLabel: 'Thickness',
             value: model.crossHairsThickness,
             min: 1,
@@ -412,6 +413,7 @@ class _CrosshairsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
+            width: 500,
             actionLabel: 'Length',
             value: model.crossHairsLength,
             min: 20,
@@ -508,6 +510,7 @@ class _ColorEffectsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
+            width: 500,
             actionLabel: 'Brightness',
             value: model.colorBrightness,
             min: -0.75,
@@ -520,6 +523,7 @@ class _ColorEffectsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
+            width: 500,
             actionLabel: 'Contrast',
             value: model.colorContrast,
             min: -0.75,
@@ -532,6 +536,7 @@ class _ColorEffectsOptions extends StatelessWidget {
         SizedBox(
           height: 56,
           child: YaruSliderRow(
+            width: 500,
             actionLabel: 'Saturation',
             value: model.colorSaturation,
             min: 0,

--- a/lib/view/pages/accessibility/typing_section.dart
+++ b/lib/view/pages/accessibility/typing_section.dart
@@ -62,6 +62,7 @@ class _RepeatKeysSettings extends StatelessWidget {
       closeIconData: YaruIcons.window_close,
       children: [
         YaruSliderRow(
+          width: 500,
           actionLabel: 'Delay',
           actionDescription: 'Initial key repeat delay',
           value: model.delay,
@@ -71,6 +72,7 @@ class _RepeatKeysSettings extends StatelessWidget {
           onChanged: (value) => model.setDelay(value),
         ),
         YaruSliderRow(
+          width: 500,
           actionLabel: 'Interval',
           actionDescription: 'Delay between repeats',
           value: model.interval,
@@ -118,6 +120,7 @@ class _CursorBlinkingSettings extends StatelessWidget {
       closeIconData: YaruIcons.window_close,
       children: [
         YaruSliderRow(
+          width: 500,
           actionLabel: 'Cursor Blink Time',
           actionDescription: 'Length of the cursor blink cycle',
           min: 100,
@@ -253,6 +256,7 @@ class _SlowKeysSettings extends StatelessWidget {
           SizedBox(
             height: 56,
             child: YaruSliderRow(
+              width: 500,
               enabled: model.slowKeys ?? false,
               actionLabel: 'Acceptance delay',
               value: model.slowKeysDelay,
@@ -300,6 +304,7 @@ class _BounceKeysSettings extends StatelessWidget {
           SizedBox(
             height: 56,
             child: YaruSliderRow(
+              width: 500,
               enabled: model.bounceKeys ?? false,
               actionLabel: 'Acceptance delay',
               value: model.bounceKeysDelay,

--- a/lib/view/pages/accessibility/typing_section.dart
+++ b/lib/view/pages/accessibility/typing_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/accessibility/accessibility_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -11,6 +12,7 @@ class TypingSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<AccessibilityModel>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Typing',
       children: [
         YaruSwitchRow(

--- a/lib/view/pages/accessibility/typing_section.dart
+++ b/lib/view/pages/accessibility/typing_section.dart
@@ -62,7 +62,7 @@ class _RepeatKeysSettings extends StatelessWidget {
       closeIconData: YaruIcons.window_close,
       children: [
         YaruSliderRow(
-          width: 500,
+          width: kDefaultWidth,
           actionLabel: 'Delay',
           actionDescription: 'Initial key repeat delay',
           value: model.delay,
@@ -72,7 +72,7 @@ class _RepeatKeysSettings extends StatelessWidget {
           onChanged: (value) => model.setDelay(value),
         ),
         YaruSliderRow(
-          width: 500,
+          width: kDefaultWidth,
           actionLabel: 'Interval',
           actionDescription: 'Delay between repeats',
           value: model.interval,
@@ -120,7 +120,7 @@ class _CursorBlinkingSettings extends StatelessWidget {
       closeIconData: YaruIcons.window_close,
       children: [
         YaruSliderRow(
-          width: 500,
+          width: kDefaultWidth,
           actionLabel: 'Cursor Blink Time',
           actionDescription: 'Length of the cursor blink cycle',
           min: 100,
@@ -256,7 +256,7 @@ class _SlowKeysSettings extends StatelessWidget {
           SizedBox(
             height: 56,
             child: YaruSliderRow(
-              width: 500,
+              width: kDefaultWidth,
               enabled: model.slowKeys ?? false,
               actionLabel: 'Acceptance delay',
               value: model.slowKeysDelay,
@@ -304,7 +304,7 @@ class _BounceKeysSettings extends StatelessWidget {
           SizedBox(
             height: 56,
             child: YaruSliderRow(
-              width: 500,
+              width: kDefaultWidth,
               enabled: model.bounceKeys ?? false,
               actionLabel: 'Acceptance delay',
               value: model.bounceKeysDelay,

--- a/lib/view/pages/appearance/appearance_page.dart
+++ b/lib/view/pages/appearance/appearance_page.dart
@@ -19,13 +19,11 @@ class AppearancePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return YaruPage(
-      child: Column(
-        children: const [
-          DarkModeSection(),
-          DockSection(),
-        ],
-      ),
+    return const YaruPage(
+      children: [
+        DarkModeSection(),
+        DockSection(),
+      ],
     );
   }
 }

--- a/lib/view/pages/appearance/dark_mode_section.dart
+++ b/lib/view/pages/appearance/dark_mode_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/app_theme.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -14,6 +15,7 @@ class DarkModeSection extends StatelessWidget {
     final lighTheme = context.watch<LightTheme>();
     final darkTheme = context.watch<DarkTheme>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Theme',
       children: [
         YaruSwitchRow(

--- a/lib/view/pages/appearance/dock_section.dart
+++ b/lib/view/pages/appearance/dock_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/utils.dart';
 import 'package:settings/view/pages/appearance/dock_model.dart';
 import 'package:settings/view/selectable_svg_image.dart';
@@ -19,198 +20,202 @@ class DockSection extends StatelessWidget {
         ? Theme.of(context).primaryColor
         : lighten(Theme.of(context).primaryColor, 20);
 
-    return Column(
-      children: [
-        YaruSection(
-          headline: 'Dock appearance',
-          children: [
-            YaruRow(
-                trailingWidget: const Text('Panel mode'),
-                description:
-                    'Extends the height of the dock to become a panel.',
-                actionWidget: Radio<bool>(
-                    value: true,
-                    groupValue: model.extendDock,
-                    onChanged: (value) => model.extendDock = value),
-                enabled: model.extendDock != null),
-            Padding(
-              padding: const EdgeInsets.all(assetPadding),
-              child: SvgPicture.asset(
-                model.getPanelModeAsset(),
-                color: (model.extendDock != null && model.extendDock == true)
-                    ? selectedColor
-                    : unselectedColor,
-                colorBlendMode:
-                    (model.extendDock != null && model.extendDock == true)
-                        ? BlendMode.srcIn
-                        : BlendMode.color,
-                height: assetHeight,
-              ),
-            ),
-            YaruRow(
-                trailingWidget: const Text('Dock mode'),
-                description:
-                    'Displays the dock in a centered, free-floating mode.',
-                actionWidget: Radio<bool>(
-                    value: false,
-                    groupValue: model.extendDock,
-                    onChanged: (value) => model.extendDock = value!),
-                enabled: true),
-            Padding(
-              padding: const EdgeInsets.all(assetPadding),
-              child: SvgPicture.asset(
-                model.getDockModeAsset(),
-                color: (model.extendDock != null && !model.extendDock!)
-                    ? selectedColor
-                    : unselectedColor,
-                colorBlendMode: (model.extendDock != null && !model.extendDock!)
-                    ? BlendMode.srcIn
-                    : BlendMode.color,
-                height: assetHeight,
-              ),
-            ),
-          ],
-        ),
-        YaruSection(headline: 'Dock Position', children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    return SizedBox(
+      width: kDefaultWidth,
+      child: Column(
+        children: [
+          YaruSection(
+            headline: 'Dock appearance',
             children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.all(8.0),
-                      child: Text('Left'),
-                    ),
-                    SizedBox(
-                      child: SelectableSvgImage(
+              YaruRow(
+                  trailingWidget: const Text('Panel mode'),
+                  description:
+                      'Extends the height of the dock to become a panel.',
+                  actionWidget: Radio<bool>(
+                      value: true,
+                      groupValue: model.extendDock,
+                      onChanged: (value) => model.extendDock = value),
+                  enabled: model.extendDock != null),
+              Padding(
+                padding: const EdgeInsets.all(assetPadding),
+                child: SvgPicture.asset(
+                  model.getPanelModeAsset(),
+                  color: (model.extendDock != null && model.extendDock == true)
+                      ? selectedColor
+                      : unselectedColor,
+                  colorBlendMode:
+                      (model.extendDock != null && model.extendDock == true)
+                          ? BlendMode.srcIn
+                          : BlendMode.color,
+                  height: assetHeight,
+                ),
+              ),
+              YaruRow(
+                  trailingWidget: const Text('Dock mode'),
+                  description:
+                      'Displays the dock in a centered, free-floating mode.',
+                  actionWidget: Radio<bool>(
+                      value: false,
+                      groupValue: model.extendDock,
+                      onChanged: (value) => model.extendDock = value!),
+                  enabled: true),
+              Padding(
+                padding: const EdgeInsets.all(assetPadding),
+                child: SvgPicture.asset(
+                  model.getDockModeAsset(),
+                  color: (model.extendDock != null && !model.extendDock!)
+                      ? selectedColor
+                      : unselectedColor,
+                  colorBlendMode:
+                      (model.extendDock != null && !model.extendDock!)
+                          ? BlendMode.srcIn
+                          : BlendMode.color,
+                  height: assetHeight,
+                ),
+              ),
+            ],
+          ),
+          YaruSection(headline: 'Dock Position', children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.all(8.0),
+                        child: Text('Left'),
+                      ),
+                      SizedBox(
+                        child: SelectableSvgImage(
+                          selectedColor: selectedColor,
+                          padding: 8.0,
+                          path: model.getLeftSideAsset(),
+                          selected: model.dockPosition == DockPosition.left,
+                          height: assetHeight,
+                          onTap: () => model.dockPosition = DockPosition.left,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.all(8.0),
+                        child: Text('Right'),
+                      ),
+                      SelectableSvgImage(
                         selectedColor: selectedColor,
                         padding: 8.0,
-                        path: model.getLeftSideAsset(),
-                        selected: model.dockPosition == DockPosition.left,
+                        path: model.getRightSideAsset(),
+                        selected: model.dockPosition == DockPosition.right,
                         height: assetHeight,
-                        onTap: () => model.dockPosition = DockPosition.left,
+                        onTap: () => model.dockPosition = DockPosition.right,
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.all(8.0),
-                      child: Text('Right'),
-                    ),
-                    SelectableSvgImage(
-                      selectedColor: selectedColor,
-                      padding: 8.0,
-                      path: model.getRightSideAsset(),
-                      selected: model.dockPosition == DockPosition.right,
-                      height: assetHeight,
-                      onTap: () => model.dockPosition = DockPosition.right,
-                    ),
-                  ],
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.all(8.0),
+                        child: Text('Bottom'),
+                      ),
+                      SelectableSvgImage(
+                        selectedColor: selectedColor,
+                        padding: 8.0,
+                        path: model.getBottomAsset(),
+                        selected: model.dockPosition == DockPosition.bottom,
+                        height: assetHeight,
+                        onTap: () => model.dockPosition = DockPosition.bottom,
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.all(8.0),
-                      child: Text('Bottom'),
-                    ),
-                    SelectableSvgImage(
-                      selectedColor: selectedColor,
-                      padding: 8.0,
-                      path: model.getBottomAsset(),
-                      selected: model.dockPosition == DockPosition.bottom,
+              ],
+            )
+          ]),
+          YaruSection(
+            headline: 'Dock options',
+            children: [
+              Column(
+                children: [
+                  YaruSwitchRow(
+                    enabled: model.alwaysShowDock != null,
+                    trailingWidget: const Text('Auto-hide the Dock'),
+                    actionDescription: 'The dock hides when windows touch it.',
+                    value: model.alwaysShowDock != null &&
+                        model.alwaysShowDock == false,
+                    onChanged: (value) => model.alwaysShowDock = !value,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(assetPadding),
+                    child: SvgPicture.asset(
+                      model.getAutoHideAsset(),
+                      color: (model.alwaysShowDock != null &&
+                              !model.alwaysShowDock!)
+                          ? selectedColor
+                          : unselectedColor,
+                      colorBlendMode: (model.alwaysShowDock != null &&
+                              !model.alwaysShowDock!)
+                          ? BlendMode.srcIn
+                          : BlendMode.color,
                       height: assetHeight,
-                      onTap: () => model.dockPosition = DockPosition.bottom,
                     ),
+                  )
+                ],
+              ),
+              YaruSwitchRow(
+                trailingWidget: const Text('Show Trash'),
+                actionDescription: 'Show the trash on the dock',
+                value: model.showTrash,
+                onChanged: (value) => model.showTrash = value,
+              ),
+              YaruSwitchRow(
+                trailingWidget: const Text('Active App Glow'),
+                actionDescription:
+                    'Colors active app icons in their primary accent color.',
+                value: model.appGlow,
+                onChanged: (value) => model.appGlow = value,
+              ),
+              YaruSliderRow(
+                enabled: model.maxIconSize != null,
+                actionLabel: 'Icon Size',
+                value: model.maxIconSize ?? 48.0,
+                min: 16,
+                max: 64,
+                defaultValue: 48,
+                onChanged: (value) => model.maxIconSize = value,
+              ),
+              YaruRow(
+                enabled: model.clickAction != null,
+                trailingWidget: const Text('App icon click behavior'),
+                actionWidget: DropdownButton<DockClickAction>(
+                  onChanged: (value) => model.clickAction = value,
+                  value: model.clickAction,
+                  items: const [
+                    DropdownMenuItem(
+                        child: Text('Minimize the app'),
+                        value: DockClickAction.minimize),
+                    DropdownMenuItem(
+                        child: Text('Cycle through windows'),
+                        value: DockClickAction.cycleWindows),
+                    DropdownMenuItem(
+                        child: Text('Focus or preview the window'),
+                        value: DockClickAction.focusOrPreviews),
                   ],
                 ),
               ),
             ],
-          )
-        ]),
-        YaruSection(
-          headline: 'Dock options',
-          children: [
-            Column(
-              children: [
-                YaruSwitchRow(
-                  enabled: model.alwaysShowDock != null,
-                  trailingWidget: const Text('Auto-hide the Dock'),
-                  actionDescription: 'The dock hides when windows touch it.',
-                  value: model.alwaysShowDock != null &&
-                      model.alwaysShowDock == false,
-                  onChanged: (value) => model.alwaysShowDock = !value,
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(assetPadding),
-                  child: SvgPicture.asset(
-                    model.getAutoHideAsset(),
-                    color:
-                        (model.alwaysShowDock != null && !model.alwaysShowDock!)
-                            ? selectedColor
-                            : unselectedColor,
-                    colorBlendMode:
-                        (model.alwaysShowDock != null && !model.alwaysShowDock!)
-                            ? BlendMode.srcIn
-                            : BlendMode.color,
-                    height: assetHeight,
-                  ),
-                )
-              ],
-            ),
-            YaruSwitchRow(
-              trailingWidget: const Text('Show Trash'),
-              actionDescription: 'Show the trash on the dock',
-              value: model.showTrash,
-              onChanged: (value) => model.showTrash = value,
-            ),
-            YaruSwitchRow(
-              trailingWidget: const Text('Active App Glow'),
-              actionDescription:
-                  'Colors active app icons in their primary accent color.',
-              value: model.appGlow,
-              onChanged: (value) => model.appGlow = value,
-            ),
-            YaruSliderRow(
-              enabled: model.maxIconSize != null,
-              actionLabel: 'Icon Size',
-              value: model.maxIconSize ?? 48.0,
-              min: 16,
-              max: 64,
-              defaultValue: 48,
-              onChanged: (value) => model.maxIconSize = value,
-            ),
-            YaruRow(
-              enabled: model.clickAction != null,
-              trailingWidget: const Text('App icon click behavior'),
-              actionWidget: DropdownButton<DockClickAction>(
-                onChanged: (value) => model.clickAction = value,
-                value: model.clickAction,
-                items: const [
-                  DropdownMenuItem(
-                      child: Text('Minimize the app'),
-                      value: DockClickAction.minimize),
-                  DropdownMenuItem(
-                      child: Text('Cycle through windows'),
-                      value: DockClickAction.cycleWindows),
-                  DropdownMenuItem(
-                      child: Text('Focus or preview the window'),
-                      value: DockClickAction.focusOrPreviews),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/pages/bluetooth/bluetooth_page.dart
+++ b/lib/view/pages/bluetooth/bluetooth_page.dart
@@ -1,6 +1,7 @@
 import 'package:bluez/bluez.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/bluetooth/bluetooth_device_row.dart';
 import 'package:settings/view/pages/bluetooth/bluetooth_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -31,27 +32,26 @@ class _BluetoothPageState extends State<BluetoothPage> {
   Widget build(BuildContext context) {
     final model = context.watch<BluetoothModel>();
     return YaruPage(
-      child: Column(
-        children: [
-          YaruSection(
-              headerWidget: const SizedBox(
-                height: 15,
-                width: 15,
-                child: CircularProgressIndicator(),
-              ),
-              headline: 'Bluetooth devices',
-              children: [
-                ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: model.devices.length,
-                  itemBuilder: (context, index) => BluetoothDeviceRow.create(
-                      context,
-                      model.devices[index],
-                      () => model.removeDevice(model.devices[index])),
-                )
-              ]),
-        ],
-      ),
+      children: [
+        YaruSection(
+            width: kDefaultWidth,
+            headerWidget: const SizedBox(
+              height: 15,
+              width: 15,
+              child: CircularProgressIndicator(),
+            ),
+            headline: 'Bluetooth devices',
+            children: [
+              ListView.builder(
+                shrinkWrap: true,
+                itemCount: model.devices.length,
+                itemBuilder: (context, index) => BluetoothDeviceRow.create(
+                    context,
+                    model.devices[index],
+                    () => model.removeDevice(model.devices[index])),
+              )
+            ]),
+      ],
     );
   }
 }

--- a/lib/view/pages/connections/connections_page.dart
+++ b/lib/view/pages/connections/connections_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nm/nm.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/connections/wifi_content.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -53,6 +54,6 @@ class _ConnectionsPageState extends State<ConnectionsPage>
       Column(
         children: const [Text('Cellular')],
       )
-    ], width: 516);
+    ], width: kDefaultWidth);
   }
 }

--- a/lib/view/pages/connections/wifi_content.dart
+++ b/lib/view/pages/connections/wifi_content.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -16,51 +17,51 @@ class WifiDevicesContent extends StatelessWidget {
     final wifiModel = context.watch<WifiModel>();
 
     return YaruPage(
-      child: Column(
-        children: [
-          YaruRow(
-              enabled: true,
-              trailingWidget: const Text('Wi-Fi'),
-              actionWidget: Row(
-                children: [
-                  Text(
-                    wifiModel.isWifiEnabled ? 'connected' : 'disconnected',
-                    style: TextStyle(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onSurface
-                            .withOpacity(0.5)),
-                  ),
-                  Switch(
-                      onChanged: (newValue) => wifiModel.toggleWifi(newValue),
-                      value: wifiModel.isWifiEnabled),
-                ],
-              )),
-          if (wifiModel.isWifiEnabled)
-            for (final wifiDevice in wifiModel.wifiDevices)
-              AnimatedBuilder(
-                  animation: wifiDevice,
-                  builder: (_, __) {
-                    return YaruSection(
-                      headline: 'Visible Networks',
-                      children: [
-                        for (final accessPoint in wifiDevice.accesPoints)
-                          AccessPointTile(
-                            accessPointModel: accessPoint,
-                            onTap: () {
-                              wifiModel.connectToAccesPoint(
-                                accessPoint,
-                                wifiDevice,
-                                (wifiDevice, accessPoint) =>
-                                    authenticate(context, accessPoint),
-                              );
-                            },
-                          )
-                      ],
-                    );
-                  })
-        ],
-      ),
+      children: [
+        YaruRow(
+            width: kDefaultWidth,
+            enabled: true,
+            trailingWidget: const Text('Wi-Fi'),
+            actionWidget: Row(
+              children: [
+                Text(
+                  wifiModel.isWifiEnabled ? 'connected' : 'disconnected',
+                  style: TextStyle(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withOpacity(0.5)),
+                ),
+                Switch(
+                    onChanged: (newValue) => wifiModel.toggleWifi(newValue),
+                    value: wifiModel.isWifiEnabled),
+              ],
+            )),
+        if (wifiModel.isWifiEnabled)
+          for (final wifiDevice in wifiModel.wifiDevices)
+            AnimatedBuilder(
+                animation: wifiDevice,
+                builder: (_, __) {
+                  return YaruSection(
+                    width: kDefaultWidth,
+                    headline: 'Visible Networks',
+                    children: [
+                      for (final accessPoint in wifiDevice.accesPoints)
+                        AccessPointTile(
+                          accessPointModel: accessPoint,
+                          onTap: () {
+                            wifiModel.connectToAccesPoint(
+                              accessPoint,
+                              wifiDevice,
+                              (wifiDevice, accessPoint) =>
+                                  authenticate(context, accessPoint),
+                            );
+                          },
+                        )
+                    ],
+                  );
+                })
+      ],
     );
   }
 

--- a/lib/view/pages/info/info_page.dart
+++ b/lib/view/pages/info/info_page.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:rive/rive.dart';
 import 'package:settings/api/pdf_api.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/services/hostname_service.dart';
 import 'package:udisks/udisks.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -53,86 +54,87 @@ class _InfoPageState extends State<InfoPage> {
     );
 
     return YaruPage(
-      child: Column(
-        children: [
-          const SizedBox(
-              height: 128,
-              width: 128,
-              child: RiveAnimation.asset('assets/rive/ubuntu_cof.riv')),
-          const SizedBox(height: 10),
-          Text('${model.osName} ${model.osVersion}',
-              style: Theme.of(context).textTheme.headline5),
-          const SizedBox(height: 10),
-          const SizedBox(height: 30),
-          const _Computer(),
-          YaruSection(headline: 'Hardware', children: [
-            YaruSingleInfoRow(
-              infoLabel: 'Processor',
-              infoValue: '${model.processorName} x ${model.processorCount}',
-            ),
-            YaruSingleInfoRow(
-              infoLabel: 'Memory',
-              infoValue: '${model.memory} Gb',
-            ),
-            YaruSingleInfoRow(
-              infoLabel: 'Graphics',
-              infoValue: model.graphics,
-            ),
-            YaruSingleInfoRow(
-              infoLabel: 'Disk Capacity',
-              infoValue: model.diskCapacity != null
-                  ? filesize(model.diskCapacity)
-                  : '',
-            ),
-          ]),
-          YaruSection(headline: 'System', children: [
-            YaruSingleInfoRow(
-              infoLabel: 'OS',
-              infoValue:
-                  '${model.osName} ${model.osVersion} (${model.osType}-bit)',
-            ),
-            YaruSingleInfoRow(
-              infoLabel: 'Kernel version',
-              infoValue: model.kernelVersion,
-            ),
-            YaruSingleInfoRow(
-              infoLabel: 'GNOME version',
-              infoValue: model.gnomeVersion,
-            ),
-            YaruSingleInfoRow(
-              infoLabel: 'Windowing System',
-              infoValue: model.windowServer,
-            ),
-          ]),
-          YaruPageContainer(
-              child: Align(
-            alignment: Alignment.topRight,
-            child: OutlinedButton.icon(
-              icon: const Icon(YaruIcons.save_as),
-              label: const Text('Export to PDF'),
-              onPressed: () async {
-                // ignore: unused_local_variable
-                final pdfFile = await PdfApi.generateSystemData(
-                  model.osName,
-                  model.osVersion,
-                  model.kernelVersion,
-                  model.processorName,
-                  model.processorCount.toString(),
-                  model.memory.toString(),
-                  model.graphics,
-                  model.diskCapacity != null
-                      ? filesize(model.diskCapacity)
-                      : '',
-                  model.osType.toString(),
-                  model.gnomeVersion,
-                  model.windowServer,
-                );
-                ScaffoldMessenger.of(context).showSnackBar(sysInfoSnackBar);
-              },
-            ),
-          )),
-        ],
-      ),
+      children: [
+        const SizedBox(
+            height: 128,
+            width: 128,
+            child: RiveAnimation.asset('assets/rive/ubuntu_cof.riv')),
+        const SizedBox(height: 10),
+        Text('${model.osName} ${model.osVersion}',
+            style: Theme.of(context).textTheme.headline5),
+        const SizedBox(height: 10),
+        const SizedBox(height: 30),
+        const _Computer(),
+        YaruSection(width: kDefaultWidth, headline: 'Hardware', children: [
+          YaruSingleInfoRow(
+            infoLabel: 'Processor',
+            infoValue: '${model.processorName} x ${model.processorCount}',
+          ),
+          YaruSingleInfoRow(
+            infoLabel: 'Memory',
+            infoValue: '${model.memory} Gb',
+          ),
+          YaruSingleInfoRow(
+            infoLabel: 'Graphics',
+            infoValue: model.graphics,
+          ),
+          YaruSingleInfoRow(
+            infoLabel: 'Disk Capacity',
+            infoValue:
+                model.diskCapacity != null ? filesize(model.diskCapacity) : '',
+          ),
+        ]),
+        YaruSection(width: kDefaultWidth, headline: 'System', children: [
+          YaruSingleInfoRow(
+            infoLabel: 'OS',
+            infoValue:
+                '${model.osName} ${model.osVersion} (${model.osType}-bit)',
+          ),
+          YaruSingleInfoRow(
+            infoLabel: 'Kernel version',
+            infoValue: model.kernelVersion,
+          ),
+          YaruSingleInfoRow(
+            infoLabel: 'GNOME version',
+            infoValue: model.gnomeVersion,
+          ),
+          YaruSingleInfoRow(
+            infoLabel: 'Windowing System',
+            infoValue: model.windowServer,
+          ),
+        ]),
+        SizedBox(
+          width: kDefaultWidth,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              OutlinedButton.icon(
+                icon: const Icon(YaruIcons.save_as),
+                label: const Text('Export to PDF'),
+                onPressed: () async {
+                  // ignore: unused_local_variable
+                  final pdfFile = await PdfApi.generateSystemData(
+                    model.osName,
+                    model.osVersion,
+                    model.kernelVersion,
+                    model.processorName,
+                    model.processorCount.toString(),
+                    model.memory.toString(),
+                    model.graphics,
+                    model.diskCapacity != null
+                        ? filesize(model.diskCapacity)
+                        : '',
+                    model.osType.toString(),
+                    model.gnomeVersion,
+                    model.windowServer,
+                  );
+                  ScaffoldMessenger.of(context).showSnackBar(sysInfoSnackBar);
+                },
+              )
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
@@ -144,7 +146,7 @@ class _Computer extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<InfoModel>();
 
-    return YaruSection(headline: 'Computer', children: [
+    return YaruSection(width: kDefaultWidth, headline: 'Computer', children: [
       YaruRow(
         enabled: true,
         trailingWidget: const Text('Hostname'),

--- a/lib/view/pages/keyboard/input_source_section.dart
+++ b/lib/view/pages/keyboard/input_source_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/keyboard/input_source_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -11,22 +12,25 @@ class InputSourceSection extends StatelessWidget {
     final inputSourceModel = context.watch<InputSourceModel>();
 
     return Column(children: [
-      YaruSection(headline: 'Change input sources', children: [
-        RadioListTile(
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-            title: const Text('Use the same input for all windows'),
-            value: false,
-            groupValue: inputSourceModel.perWindow,
-            onChanged: (_) => inputSourceModel.perWindow = false),
-        RadioListTile(
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-            title: const Text('Give each window its own input source'),
-            value: true,
-            groupValue: inputSourceModel.perWindow,
-            onChanged: (_) => inputSourceModel.perWindow = true)
-      ])
+      YaruSection(
+          width: kDefaultWidth,
+          headline: 'Change input sources',
+          children: [
+            RadioListTile(
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4)),
+                title: const Text('Use the same input for all windows'),
+                value: false,
+                groupValue: inputSourceModel.perWindow,
+                onChanged: (_) => inputSourceModel.perWindow = false),
+            RadioListTile(
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4)),
+                title: const Text('Give each window its own input source'),
+                value: true,
+                groupValue: inputSourceModel.perWindow,
+                onChanged: (_) => inputSourceModel.perWindow = true)
+          ])
     ]);
   }
 }

--- a/lib/view/pages/keyboard/input_source_selection_section.dart
+++ b/lib/view/pages/keyboard/input_source_selection_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/keyboard/input_source_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -20,6 +21,7 @@ class InputSourceSelectionSection extends StatelessWidget {
           return const CircularProgressIndicator();
         }
         return YaruSection(
+            width: kDefaultWidth,
             headline: 'Input Sources',
             headerWidget: SizedBox(
               height: 40,

--- a/lib/view/pages/keyboard/keyboard_page.dart
+++ b/lib/view/pages/keyboard/keyboard_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/keyboard/keyboard_settings_page.dart';
 import 'package:settings/view/pages/keyboard/keyboard_shortcuts_page.dart';
 import 'package:yaru_icons/yaru_icons.dart';
@@ -31,7 +32,7 @@ class _KeyboardPageState extends State<KeyboardPage>
       tabIcons: [YaruIcons.input_keyboard, YaruIcons.keyboard_shortcuts],
       tabTitles: ['Keyboard Settings', 'Keyboard Shortcuts'],
       views: [KeyboardSettingsPage(), KeyboardShortcutsPage()],
-      width: 512,
+      width: kDefaultWidth,
     );
   }
 }

--- a/lib/view/pages/keyboard/keyboard_settings_page.dart
+++ b/lib/view/pages/keyboard/keyboard_settings_page.dart
@@ -22,7 +22,6 @@ class KeyboardSettingsPage extends StatelessWidget {
         Provider.of<InputSourceService>(context, listen: false);
 
     return YaruPage(
-        child: Column(
       children: [
         ChangeNotifierProvider(
           create: (_) => InputSourceModel(settingsService, inputSourceService),
@@ -37,6 +36,6 @@ class KeyboardSettingsPage extends StatelessWidget {
           child: const SpecialCharactersSection(),
         ),
       ],
-    ));
+    );
   }
 }

--- a/lib/view/pages/keyboard/keyboard_shortcuts_page.dart
+++ b/lib/view/pages/keyboard/keyboard_shortcuts_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/schemas/schemas.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/keyboard/keyboard_shortcut_row.dart';
@@ -14,39 +15,39 @@ class KeyboardShortcutsPage extends StatelessWidget {
     final service = Provider.of<SettingsService>(context, listen: false);
 
     return YaruPage(
-      child: Column(
-        children: [
-          ChangeNotifierProvider(
-            create: (_) =>
-                KeyboardShortcutsModel(service, schemaId: schemaWmKeybindings),
+      children: [
+        ChangeNotifierProvider(
+          create: (_) =>
+              KeyboardShortcutsModel(service, schemaId: schemaWmKeybindings),
+          child: const YaruSection(
+            width: kDefaultWidth,
+            headline: 'Navigation Shortcuts',
+            children: [
+              KeyboardShortcutRow(
+                label: 'Switch windows',
+                shortcutId: 'switch-windows',
+              ),
+              KeyboardShortcutRow(
+                label: 'Switch windows backward',
+                shortcutId: 'switch-windows-backward',
+              ),
+            ],
+          ),
+        ),
+        ChangeNotifierProvider(
+            create: (_) => KeyboardShortcutsModel(service,
+                schemaId: schemaGnomeShellKeybinding),
             child: const YaruSection(
-              headline: 'Navigation Shortcuts',
+              width: kDefaultWidth,
+              headline: 'System',
               children: [
                 KeyboardShortcutRow(
-                  label: 'Switch windows',
-                  shortcutId: 'switch-windows',
-                ),
-                KeyboardShortcutRow(
-                  label: 'Switch windows backward',
-                  shortcutId: 'switch-windows-backward',
+                  label: 'Toggle Apps Grid',
+                  shortcutId: 'toggle-application-view',
                 ),
               ],
-            ),
-          ),
-          ChangeNotifierProvider(
-              create: (_) => KeyboardShortcutsModel(service,
-                  schemaId: schemaGnomeShellKeybinding),
-              child: const YaruSection(
-                headline: 'System',
-                children: [
-                  KeyboardShortcutRow(
-                    label: 'Toggle Apps Grid',
-                    shortcutId: 'toggle-application-view',
-                  ),
-                ],
-              ))
-        ],
-      ),
+            ))
+      ],
     );
   }
 }

--- a/lib/view/pages/keyboard/special_characters_section.dart
+++ b/lib/view/pages/keyboard/special_characters_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/keyboard/special_characters_model.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -13,46 +14,49 @@ class SpecialCharactersSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final model = context.watch<SpecialCharactersModel>();
 
-    return YaruSection(headline: 'Special characters', children: [
-      FutureBuilder<ComposeOptions>(
-          future: model.getComposeOptions(),
-          builder: (context, snapshot) => InkWell(
-                borderRadius: BorderRadius.circular(4),
-                onTap: () => showDialog(
+    return YaruSection(
+        width: kDefaultWidth,
+        headline: 'Special characters',
+        children: [
+          FutureBuilder<ComposeOptions>(
+              future: model.getComposeOptions(),
+              builder: (context, snapshot) => InkWell(
+                    borderRadius: BorderRadius.circular(4),
+                    onTap: () => showDialog(
+                      context: context,
+                      builder: (_) => ChangeNotifierProvider.value(
+                        value: model,
+                        child: const _ComposeOptionsDialog(),
+                      ),
+                    ),
+                    child: YaruRow(
+                      enabled: true,
+                      trailingWidget: const Text('Compose Key'),
+                      actionWidget: Text(snapshot.hasData
+                          ? model.composeOptionsToStringMap[snapshot.data]!
+                          : ''),
+                    ),
+                  )),
+          FutureBuilder<Lv3Options?>(
+            future: model.getLv3Options(),
+            builder: (context, snapshot) => InkWell(
+              borderRadius: BorderRadius.circular(4),
+              onTap: () => showDialog(
                   context: context,
                   builder: (_) => ChangeNotifierProvider.value(
-                    value: model,
-                    child: const _ComposeOptionsDialog(),
-                  ),
-                ),
-                child: YaruRow(
-                  enabled: true,
-                  trailingWidget: const Text('Compose Key'),
-                  actionWidget: Text(snapshot.hasData
-                      ? model.composeOptionsToStringMap[snapshot.data]!
-                      : ''),
-                ),
-              )),
-      FutureBuilder<Lv3Options?>(
-        future: model.getLv3Options(),
-        builder: (context, snapshot) => InkWell(
-          borderRadius: BorderRadius.circular(4),
-          onTap: () => showDialog(
-              context: context,
-              builder: (_) => ChangeNotifierProvider.value(
-                    value: model,
-                    child: const _Lv3OptionsDialog(),
-                  )),
-          child: YaruRow(
-            enabled: true,
-            trailingWidget: const Text('Lv3 Key'),
-            actionWidget: Text(snapshot.hasData
-                ? model.lv3OptionsToStringMap[snapshot.data]!
-                : 'Default Layout'),
-          ),
-        ),
-      )
-    ]);
+                        value: model,
+                        child: const _Lv3OptionsDialog(),
+                      )),
+              child: YaruRow(
+                enabled: true,
+                trailingWidget: const Text('Lv3 Key'),
+                actionWidget: Text(snapshot.hasData
+                    ? model.lv3OptionsToStringMap[snapshot.data]!
+                    : 'Default Layout'),
+              ),
+            ),
+          )
+        ]);
   }
 }
 

--- a/lib/view/pages/mouse_and_touchpad/general_section.dart
+++ b/lib/view/pages/mouse_and_touchpad/general_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import 'mouse_and_touchpad_model.dart';
@@ -12,6 +13,7 @@ class GeneralSection extends StatelessWidget {
     final model = context.watch<MouseAndTouchpadModel>();
 
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'General',
       children: [
         YaruToggleButtonsRow(

--- a/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_page.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_and_touchpad_page.dart
@@ -20,14 +20,12 @@ class MouseAndTouchpadPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return YaruPage(
-      child: Column(
-        children: const [
-          GeneralSection(),
-          MouseSection(),
-          TouchpadSection(),
-        ],
-      ),
+    return const YaruPage(
+      children: [
+        GeneralSection(),
+        MouseSection(),
+        TouchpadSection(),
+      ],
     );
   }
 }

--- a/lib/view/pages/mouse_and_touchpad/mouse_section.dart
+++ b/lib/view/pages/mouse_and_touchpad/mouse_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -11,6 +12,7 @@ class MouseSection extends StatelessWidget {
     final model = context.watch<MouseAndTouchpadModel>();
 
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Mouse',
       children: [
         YaruSliderRow(

--- a/lib/view/pages/mouse_and_touchpad/touchpad_section.dart
+++ b/lib/view/pages/mouse_and_touchpad/touchpad_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/mouse_and_touchpad/mouse_and_touchpad_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -11,6 +12,7 @@ class TouchpadSection extends StatelessWidget {
     final model = context.watch<MouseAndTouchpadModel>();
 
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Touchpad',
       children: [
         YaruSliderRow(

--- a/lib/view/pages/multitasking/multi_tasking_page.dart
+++ b/lib/view/pages/multitasking/multi_tasking_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/utils.dart';
 import 'package:settings/view/pages/multitasking/multi_tasking_model.dart';
@@ -27,164 +28,162 @@ class MultiTaskingPage extends StatelessWidget {
         : lighten(Theme.of(context).primaryColor, 20);
 
     return YaruPage(
-      child: Column(
-        children: [
-          YaruSection(headline: 'General', children: [
-            Column(
-              children: [
-                YaruSwitchRow(
-                  actionDescription:
-                      'Touch the top-left corner to open the Activities Overview.',
-                  trailingWidget: const Text('Hot corner'),
-                  value: model.enableHotCorners,
-                  onChanged: (value) => model.enableHotCorners = value,
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(20.0),
-                  child: SvgPicture.asset(
-                    model.getHotCornerAsset(),
-                    color: (model.enableHotCorners != null &&
-                            model.enableHotCorners == true)
-                        ? selectedColor
-                        : unselectedColor,
-                    colorBlendMode: (model.enableHotCorners != null &&
-                            model.enableHotCorners == true)
-                        ? BlendMode.srcIn
-                        : BlendMode.color,
-                    height: 80,
-                  ),
-                ),
-              ],
-            ),
-            Column(
-              children: [
-                YaruSwitchRow(
-                  actionDescription:
-                      'Drag windows against top, left and right screen edges to resize them',
-                  trailingWidget: const Text('Enable active edge tiling'),
-                  value: model.edgeTiling,
-                  onChanged: (value) => model.edgeTiling = value,
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(20.0),
-                  child: SvgPicture.asset(
-                    model.getActiveEdgesAsset(),
-                    color: model.edgeTiling != null && model.edgeTiling == true
-                        ? selectedColor
-                        : unselectedColor,
-                    colorBlendMode:
-                        model.edgeTiling != null && model.edgeTiling == true
-                            ? BlendMode.srcIn
-                            : BlendMode.color,
-                    height: 80,
-                  ),
-                ),
-              ],
-            )
-          ]),
-          YaruSection(headline: 'Workspaces', children: [
-            RadioListTile<bool>(
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(4)),
-              title: const Text('Dynamic Workspaces'),
-              value: true,
-              groupValue: model.dynamicWorkspaces,
-              onChanged: (value) => model.dynamicWorkspaces = value,
-            ),
-            RadioListTile<bool>(
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(4)),
-              title: const Text('Fixed number of workspaces'),
-              value: false,
-              groupValue: model.dynamicWorkspaces,
-              onChanged: (value) => model.dynamicWorkspaces = value!,
-            ),
-            YaruRow(
-                enabled: model.dynamicWorkspaces != null &&
-                    model.dynamicWorkspaces == false,
-                trailingWidget: const Text('Number of workspaces'),
-                actionWidget: SizedBox(
-                  height: 40,
-                  width: 150,
-                  child: SpinBox(
-                    min: 1,
-                    decoration:
-                        const InputDecoration(border: UnderlineInputBorder()),
-                    enabled: model.dynamicWorkspaces != null &&
-                        model.dynamicWorkspaces == false,
-                    value: model.numWorkspaces != null
-                        ? model.numWorkspaces!.toDouble()
-                        : 0,
-                    onChanged: (value) => model.numWorkspaces = value.toInt(),
-                  ),
-                ))
-          ]),
-          YaruSection(headline: 'Multi-Monitor', children: [
-            YaruRow(
-                trailingWidget: const Text('Workspaces span all displays'),
-                description:
-                    'All displays are included in one workspace and follow when you switch workspaces.',
-                actionWidget: Radio(
-                    value: false,
-                    groupValue: model.workSpaceOnlyOnPrimary,
-                    onChanged: (bool? value) =>
-                        model.workSpaceOnlyOnPrimary = value),
-                enabled: model.workSpaceOnlyOnPrimary != null),
-            Padding(
-              padding: const EdgeInsets.all(10.0),
-              child: SvgPicture.asset(
-                model.getWorkspacesSpanDisplayAsset(),
-                color: !(model.workSpaceOnlyOnPrimary != null &&
-                        model.workSpaceOnlyOnPrimary == true)
-                    ? selectedColor
-                    : unselectedColor,
-                colorBlendMode: !(model.workSpaceOnlyOnPrimary != null &&
-                        model.workSpaceOnlyOnPrimary == true)
-                    ? BlendMode.srcIn
-                    : BlendMode.color,
-                height: 60,
-              ),
-            ),
-            YaruRow(
-                trailingWidget:
-                    const Text('Workspaces only on primary display'),
-                description:
-                    'Only your primary display is included in workspace switching.',
-                actionWidget: Radio(
-                    value: true,
-                    groupValue: model.workSpaceOnlyOnPrimary,
-                    onChanged: (bool? value) =>
-                        model.workSpaceOnlyOnPrimary = value),
-                enabled: model.workSpaceOnlyOnPrimary != null),
-            Padding(
-              padding: const EdgeInsets.all(10.0),
-              child: SvgPicture.asset(
-                model.getWorkspacesPrimaryDisplayAsset(),
-                color: !(model.workSpaceOnlyOnPrimary != null &&
-                        model.workSpaceOnlyOnPrimary == false)
-                    ? selectedColor
-                    : unselectedColor,
-                colorBlendMode: !(model.workSpaceOnlyOnPrimary != null &&
-                        model.workSpaceOnlyOnPrimary == false)
-                    ? BlendMode.srcIn
-                    : BlendMode.color,
-                height: 60,
-              ),
-            )
-          ]),
-          YaruSection(
-            headline: 'Application Switching',
+      children: [
+        YaruSection(width: kDefaultWidth, headline: 'General', children: [
+          Column(
             children: [
               YaruSwitchRow(
-                trailingWidget:
-                    const Text('Show applications from current workspace only'),
-                value: model.currentWorkspaceOnly,
-                onChanged: (value) => model.currentWorkspaceOnly = value,
+                actionDescription:
+                    'Touch the top-left corner to open the Activities Overview.',
+                trailingWidget: const Text('Hot corner'),
+                value: model.enableHotCorners,
+                onChanged: (value) => model.enableHotCorners = value,
+              ),
+              Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: SvgPicture.asset(
+                  model.getHotCornerAsset(),
+                  color: (model.enableHotCorners != null &&
+                          model.enableHotCorners == true)
+                      ? selectedColor
+                      : unselectedColor,
+                  colorBlendMode: (model.enableHotCorners != null &&
+                          model.enableHotCorners == true)
+                      ? BlendMode.srcIn
+                      : BlendMode.color,
+                  height: 80,
+                ),
               ),
             ],
           ),
-        ],
-      ),
+          Column(
+            children: [
+              YaruSwitchRow(
+                actionDescription:
+                    'Drag windows against top, left and right screen edges to resize them',
+                trailingWidget: const Text('Enable active edge tiling'),
+                value: model.edgeTiling,
+                onChanged: (value) => model.edgeTiling = value,
+              ),
+              Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: SvgPicture.asset(
+                  model.getActiveEdgesAsset(),
+                  color: model.edgeTiling != null && model.edgeTiling == true
+                      ? selectedColor
+                      : unselectedColor,
+                  colorBlendMode:
+                      model.edgeTiling != null && model.edgeTiling == true
+                          ? BlendMode.srcIn
+                          : BlendMode.color,
+                  height: 80,
+                ),
+              ),
+            ],
+          )
+        ]),
+        YaruSection(width: kDefaultWidth, headline: 'Workspaces', children: [
+          RadioListTile<bool>(
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+            title: const Text('Dynamic Workspaces'),
+            value: true,
+            groupValue: model.dynamicWorkspaces,
+            onChanged: (value) => model.dynamicWorkspaces = value,
+          ),
+          RadioListTile<bool>(
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+            title: const Text('Fixed number of workspaces'),
+            value: false,
+            groupValue: model.dynamicWorkspaces,
+            onChanged: (value) => model.dynamicWorkspaces = value!,
+          ),
+          YaruRow(
+              enabled: model.dynamicWorkspaces != null &&
+                  model.dynamicWorkspaces == false,
+              trailingWidget: const Text('Number of workspaces'),
+              actionWidget: SizedBox(
+                height: 40,
+                width: 150,
+                child: SpinBox(
+                  min: 1,
+                  decoration:
+                      const InputDecoration(border: UnderlineInputBorder()),
+                  enabled: model.dynamicWorkspaces != null &&
+                      model.dynamicWorkspaces == false,
+                  value: model.numWorkspaces != null
+                      ? model.numWorkspaces!.toDouble()
+                      : 0,
+                  onChanged: (value) => model.numWorkspaces = value.toInt(),
+                ),
+              ))
+        ]),
+        YaruSection(width: kDefaultWidth, headline: 'Multi-Monitor', children: [
+          YaruRow(
+              trailingWidget: const Text('Workspaces span all displays'),
+              description:
+                  'All displays are included in one workspace and follow when you switch workspaces.',
+              actionWidget: Radio(
+                  value: false,
+                  groupValue: model.workSpaceOnlyOnPrimary,
+                  onChanged: (bool? value) =>
+                      model.workSpaceOnlyOnPrimary = value),
+              enabled: model.workSpaceOnlyOnPrimary != null),
+          Padding(
+            padding: const EdgeInsets.all(10.0),
+            child: SvgPicture.asset(
+              model.getWorkspacesSpanDisplayAsset(),
+              color: !(model.workSpaceOnlyOnPrimary != null &&
+                      model.workSpaceOnlyOnPrimary == true)
+                  ? selectedColor
+                  : unselectedColor,
+              colorBlendMode: !(model.workSpaceOnlyOnPrimary != null &&
+                      model.workSpaceOnlyOnPrimary == true)
+                  ? BlendMode.srcIn
+                  : BlendMode.color,
+              height: 60,
+            ),
+          ),
+          YaruRow(
+              trailingWidget: const Text('Workspaces only on primary display'),
+              description:
+                  'Only your primary display is included in workspace switching.',
+              actionWidget: Radio(
+                  value: true,
+                  groupValue: model.workSpaceOnlyOnPrimary,
+                  onChanged: (bool? value) =>
+                      model.workSpaceOnlyOnPrimary = value),
+              enabled: model.workSpaceOnlyOnPrimary != null),
+          Padding(
+            padding: const EdgeInsets.all(10.0),
+            child: SvgPicture.asset(
+              model.getWorkspacesPrimaryDisplayAsset(),
+              color: !(model.workSpaceOnlyOnPrimary != null &&
+                      model.workSpaceOnlyOnPrimary == false)
+                  ? selectedColor
+                  : unselectedColor,
+              colorBlendMode: !(model.workSpaceOnlyOnPrimary != null &&
+                      model.workSpaceOnlyOnPrimary == false)
+                  ? BlendMode.srcIn
+                  : BlendMode.color,
+              height: 60,
+            ),
+          )
+        ]),
+        YaruSection(
+          width: kDefaultWidth,
+          headline: 'Application Switching',
+          children: [
+            YaruSwitchRow(
+              trailingWidget:
+                  const Text('Show applications from current workspace only'),
+              value: model.currentWorkspaceOnly,
+              onChanged: (value) => model.currentWorkspaceOnly = value,
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/view/pages/notifications/app_notifications_section.dart
+++ b/lib/view/pages/notifications/app_notifications_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/notifications/notifications_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -12,6 +13,7 @@ class AppNotificationsSection extends StatelessWidget {
     final model = context.watch<NotificationsModel>();
 
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'App notifications',
       children: model.applications
               ?.map((appId) =>

--- a/lib/view/pages/notifications/global_notifications_section.dart
+++ b/lib/view/pages/notifications/global_notifications_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/notifications/notifications_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -11,6 +12,7 @@ class GlobalNotificationsSection extends StatelessWidget {
     final model = context.watch<NotificationsModel>();
 
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Global',
       children: [
         YaruSwitchRow(

--- a/lib/view/pages/notifications/notifications_page.dart
+++ b/lib/view/pages/notifications/notifications_page.dart
@@ -19,13 +19,11 @@ class NotificationsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return YaruPage(
-      child: Column(
-        children: const [
-          GlobalNotificationsSection(),
-          AppNotificationsSection(),
-        ],
-      ),
+    return const YaruPage(
+      children: [
+        GlobalNotificationsSection(),
+        AppNotificationsSection(),
+      ],
     );
   }
 }

--- a/lib/view/pages/power/battery_section.dart
+++ b/lib/view/pages/power/battery_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/view/pages/power/battery_model.dart';
 import 'package:settings/view/pages/power/battery_widgets.dart';
 import 'package:upower/upower.dart';
@@ -33,6 +34,7 @@ class _BatterySectionState extends State<BatterySection> {
   Widget build(BuildContext context) {
     final model = context.watch<BatteryModel>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Battery',
       children: <Widget>[
         Padding(

--- a/lib/view/pages/power/power_page.dart
+++ b/lib/view/pages/power/power_page.dart
@@ -14,14 +14,12 @@ class PowerPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return YaruPage(
-      child: Column(
-        children: <Widget>[
-          BatterySection.create(context),
-          PowerProfileSection.create(context),
-          PowerSettingsSection.create(context),
-          SuspendSection.create(context),
-        ],
-      ),
+      children: <Widget>[
+        BatterySection.create(context),
+        PowerProfileSection.create(context),
+        PowerSettingsSection.create(context),
+        SuspendSection.create(context),
+      ],
     );
   }
 }

--- a/lib/view/pages/power/power_profile_section.dart
+++ b/lib/view/pages/power/power_profile_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/services/power_profile_service.dart';
 import 'package:settings/view/pages/power/power_profile_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -29,6 +30,7 @@ class _PowerProfileSectionState extends State<PowerProfileSection> {
   Widget build(BuildContext context) {
     final model = context.watch<PowerProfileModel>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Power Mode',
       children: <Widget>[
         RadioListTile<PowerProfile>(

--- a/lib/view/pages/power/power_settings_section.dart
+++ b/lib/view/pages/power/power_settings_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nm/nm.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/services/bluetooth_service.dart';
 import 'package:settings/services/power_settings_service.dart';
 import 'package:settings/services/settings_service.dart';
@@ -41,6 +42,7 @@ class _PowerSettingsSectionState extends State<PowerSettingsSection> {
   Widget build(BuildContext context) {
     final model = context.watch<SuspendModel>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Power Saving',
       children: <Widget>[
         YaruSliderRow(

--- a/lib/view/pages/power/suspend_section.dart
+++ b/lib/view/pages/power/suspend_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/power/suspend.dart';
 import 'package:settings/view/pages/power/suspend_model.dart';
@@ -26,6 +27,7 @@ class _SuspendSectionState extends State<SuspendSection> {
   Widget build(BuildContext context) {
     final model = context.watch<SuspendModel>();
     return YaruSection(
+      width: kDefaultWidth,
       headline: 'Suspend & Power Button',
       children: <Widget>[
         YaruRow(

--- a/lib/view/pages/removable_media/removable_media_page.dart
+++ b/lib/view/pages/removable_media/removable_media_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/removable_media/removable_media_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -20,31 +21,37 @@ class RemovableMediaPage extends StatelessWidget {
     final model = context.watch<RemovableMediaModel>();
 
     return YaruPage(
-      child: YaruSection(headline: 'Removable Media', children: [
-        SizedBox(
-          width: 500,
-          child: Padding(
-            padding: const EdgeInsets.only(top: 8, right: 8, bottom: 8),
-            child: YaruCheckboxRow(
-                enabled: true,
-                value: model.autoRunNever,
-                onChanged: (value) => model.autoRunNever = value!,
-                text: 'Never ask or start a program for any removable media'),
-          ),
-        ),
-        for (var mimeType in RemovableMediaModel.mimeTypes.entries)
-          YaruRow(
-              enabled: true,
-              trailingWidget: Text(mimeType.value),
-              actionWidget: DropdownButton<String>(
-                  value: model.getMimeTypeBehavior(mimeType.key),
-                  onChanged: (string) =>
-                      model.setMimeTypeBehavior(string!, mimeType.key),
-                  items: [
-                    for (var string in RemovableMediaModel.mimeTypeBehaviors)
-                      DropdownMenuItem(child: Text(string), value: string),
-                  ])),
-      ]),
+      children: [
+        YaruSection(
+            width: kDefaultWidth,
+            headline: 'Removable Media',
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 8, right: 8, bottom: 8),
+                child: YaruCheckboxRow(
+                    enabled: true,
+                    value: model.autoRunNever,
+                    onChanged: (value) => model.autoRunNever = value!,
+                    text:
+                        'Never ask or start a program for any removable media'),
+              ),
+              if (!model.autoRunNever)
+                for (var mimeType in RemovableMediaModel.mimeTypes.entries)
+                  YaruRow(
+                      enabled: !model.autoRunNever,
+                      trailingWidget: Text(mimeType.value),
+                      actionWidget: DropdownButton<String>(
+                          value: model.getMimeTypeBehavior(mimeType.key),
+                          onChanged: (string) =>
+                              model.setMimeTypeBehavior(string!, mimeType.key),
+                          items: [
+                            for (var string
+                                in RemovableMediaModel.mimeTypeBehaviors)
+                              DropdownMenuItem(
+                                  child: Text(string), value: string),
+                          ])),
+            ]),
+      ],
     );
   }
 }

--- a/lib/view/pages/sound/sound_page.dart
+++ b/lib/view/pages/sound/sound_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
+import 'package:settings/constants.dart';
 import 'package:settings/services/settings_service.dart';
 import 'package:settings/view/pages/sound/sound_model.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -20,34 +21,33 @@ class SoundPage extends StatelessWidget {
     final model = context.watch<SoundModel>();
 
     return YaruPage(
-      child: Column(
-        children: [
-          YaruSection(
-            headline: 'System',
-            children: [
-              YaruSwitchRow(
-                trailingWidget: const Text('Allow Volume Above 100%'),
-                value: model.allowAbove100,
-                onChanged: (value) => model.setAllowAbove100(value),
-              ),
-              YaruSwitchRow(
-                trailingWidget: const Text('Event Sounds'),
-                actionDescription:
-                    'Notify of a system action, notification or event',
-                value: model.eventSounds,
-                onChanged: (value) => model.setEventSounds(value),
-              ),
-              YaruSwitchRow(
-                trailingWidget: const Text('Input Feedback Sounds'),
-                actionDescription: 'Feedback for user input events, '
-                    'such as mouse clicks, or key presses',
-                value: model.inputFeedbackSounds,
-                onChanged: (value) => model.setInputFeedbackSounds(value),
-              ),
-            ],
-          ),
-        ],
-      ),
+      children: [
+        YaruSection(
+          width: kDefaultWidth,
+          headline: 'System',
+          children: [
+            YaruSwitchRow(
+              trailingWidget: const Text('Allow Volume Above 100%'),
+              value: model.allowAbove100,
+              onChanged: (value) => model.setAllowAbove100(value),
+            ),
+            YaruSwitchRow(
+              trailingWidget: const Text('Event Sounds'),
+              actionDescription:
+                  'Notify of a system action, notification or event',
+              value: model.eventSounds,
+              onChanged: (value) => model.setEventSounds(value),
+            ),
+            YaruSwitchRow(
+              trailingWidget: const Text('Input Feedback Sounds'),
+              actionDescription: 'Feedback for user input events, '
+                  'such as mouse clicks, or key presses',
+              value: model.inputFeedbackSounds,
+              onChanged: (value) => model.setInputFeedbackSounds(value),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/view/pages/wallpaper/wallpaper_page.dart
+++ b/lib/view/pages/wallpaper/wallpaper_page.dart
@@ -26,7 +26,7 @@ class WallpaperPage extends StatelessWidget {
 
     return YaruPage(
       padding: const EdgeInsets.all(10),
-      child: Column(children: [
+      children: [
         YaruRow(
             width: 540,
             enabled: true,
@@ -66,7 +66,6 @@ class WallpaperPage extends StatelessWidget {
               ? Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: SizedBox(
-                    width: 500,
                     height: 255,
                     child: DecoratedBox(
                       decoration: BoxDecoration(
@@ -132,7 +131,6 @@ class WallpaperPage extends StatelessWidget {
                   builder: (context, snapshot) {
                     if (snapshot.hasData) {
                       return SizedBox(
-                        // width: 500,
                         child: GridView(
                           gridDelegate:
                               const SliverGridDelegateWithMaxCrossAxisExtent(
@@ -215,7 +213,6 @@ class WallpaperPage extends StatelessWidget {
                   builder: (context, snapshot) {
                     if (snapshot.hasData) {
                       return SizedBox(
-                        // width: 500,
                         child: GridView(
                             gridDelegate:
                                 const SliverGridDelegateWithMaxCrossAxisExtent(
@@ -244,7 +241,7 @@ class WallpaperPage extends StatelessWidget {
                   }),
             ],
           ),
-      ]),
+      ],
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.8"
+    version: "3.1.9"
   args:
     dependency: transitive
     description:
@@ -877,7 +877,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: f7586fd946742be816e55a7a61476f346134b960
+      resolved-ref: "408c2ef1d8e351220dae531611be94e749adc388"
       url: "https://github.com/ubuntu/yaru.dart"
     source: git
     version: "0.2.0"
@@ -893,7 +893,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "21e120c7641dc6ffaa0bf69623b02f57b7ff974a"
+      resolved-ref: "9cbe01acf86bac41f8554fb8d0d52caf03d40f24"
       url: "https://github.com/ubuntu/yaru_widgets.dart"
     source: git
     version: "1.0.0+1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,3 +76,4 @@ flutter:
     - assets/images/appearance/auto-hide-panel-mode/
     - assets/images/appearance/auto-hide-dock-mode/
     - assets/rive/
+    - assets/pdf_assets/


### PR DESCRIPTION
yaru_widgets is now a lot more flexible with pages, sections and rows. 
This PR uses the new yaru widgets version from git and also sneakily fixes an error in the info page with a missing asset in pubspec.yaml :)
No visual changes (I hope)

@Jupi007 and/or @mivoligo can you double check?
You might need to pub upgrade and then get to use the new version of yaru widgets also locally