### PR TITLE
BluetoothPage: dialog improvements

### DIFF
--- a/lib/view/pages/bluetooth/bluetooth_device_row.dart
+++ b/lib/view/pages/bluetooth/bluetooth_device_row.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:settings/view/pages/bluetooth/bluetooth_device_model.dart';
 import 'package:settings/view/pages/bluetooth/bluetooth_device_types.dart';
+import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 import 'package:settings/l10n/l10n.dart';
 
@@ -43,125 +44,14 @@ class _BluetoothDeviceRowState extends State<BluetoothDeviceRow> {
     final model = context.watch<BluetoothDeviceModel>();
     return InkWell(
       borderRadius: BorderRadius.circular(4.0),
-      onTap: () => setState(() {
-        showDialog(
-            context: context,
-            builder: (context) => StatefulBuilder(builder: (context, setState) {
-                  return AlertDialog(
-                    title: Padding(
-                      padding:
-                          const EdgeInsets.only(right: 8, left: 8, bottom: 8),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Flexible(
-                            child: RichText(
-                              text: TextSpan(
-                                  text: model.name,
-                                  style: Theme.of(context).textTheme.headline6),
-                              maxLines: 10,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.only(left: 10),
-                            child: Icon(
-                                BluetoothDeviceTypes.getIconForAppearanceCode(
-                                    model.appearance)),
-                          )
-                        ],
-                      ),
-                    ),
-                    content: SizedBox(
-                      height: model.errorMessage.isEmpty ? 270 : 320,
-                      width: 300,
-                      child: SingleChildScrollView(
-                        child: Column(
-                          children: [
-                            YaruRow(
-                                enabled: true,
-                                trailingWidget: model.connected
-                                    ? Text(context.l10n.connected)
-                                    : Text(context.l10n.disonnected),
-                                actionWidget: Switch(
-                                    value: model.connected,
-                                    onChanged: (connectRequested) async {
-                                      connectRequested
-                                          ? await model.connect()
-                                          : await model.disconnect();
-                                      setState(() {});
-                                    })),
-                            YaruRow(
-                                enabled: true,
-                                trailingWidget: Text(context.l10n.paired),
-                                actionWidget: Padding(
-                                  padding: const EdgeInsets.only(right: 8),
-                                  child: Text(model.paired
-                                      ? context.l10n.yes
-                                      : context.l10n.no),
-                                )),
-                            YaruRow(
-                                enabled: true,
-                                trailingWidget: Text(context.l10n.address),
-                                actionWidget: Padding(
-                                  padding: const EdgeInsets.only(right: 8),
-                                  child: Text(model.address),
-                                )),
-                            YaruRow(
-                                enabled: true,
-                                trailingWidget: Text(context.l10n.type),
-                                actionWidget: Padding(
-                                  padding: const EdgeInsets.only(right: 8),
-                                  child: Text(BluetoothDeviceTypes
-                                          .map[model.appearance] ??
-                                      context.l10n.unknown),
-                                )),
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                  top: 16, bottom: 8, right: 8, left: 8),
-                              child: SizedBox(
-                                width: 300,
-                                child: OutlinedButton(
-                                    onPressed: () {
-                                      if (BluetoothDeviceTypes.isMouse(
-                                          model.appearance)) {
-                                        // TODO: get route name from model
-                                        Navigator.of(context)
-                                            .pushNamed('routeName');
-                                      }
-                                    },
-                                    child: Text(context
-                                        .l10n.bluetoothOpenDeviceSettings)),
-                              ),
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.all(8),
-                              child: SizedBox(
-                                width: 300,
-                                child: TextButton(
-                                    onPressed: () async {
-                                      await model.disconnect();
-                                      widget.removeDevice;
-
-                                      Navigator.of(context).pop();
-                                    },
-                                    child: Text(
-                                        context.l10n.bluetoothRemoveDevice)),
-                              ),
-                            ),
-                            if (model.errorMessage.isNotEmpty)
-                              Text(
-                                model.errorMessage,
-                                style: TextStyle(
-                                    color: Theme.of(context).errorColor),
-                              )
-                          ],
-                        ),
-                      ),
-                    ),
-                  );
-                }));
-      }),
+      onTap: () => showDialog(
+          context: context,
+          builder: (context) => ChangeNotifierProvider.value(
+                value: model,
+                child: _BluetoothDeviceDialog(
+                  removeDevice: widget.removeDevice,
+                ),
+              )),
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: YaruRow(
@@ -176,6 +66,96 @@ class _BluetoothDeviceRowState extends State<BluetoothDeviceRow> {
                       Theme.of(context).colorScheme.onSurface.withOpacity(0.7)),
             )),
       ),
+    );
+  }
+}
+
+class _BluetoothDeviceDialog extends StatelessWidget {
+  const _BluetoothDeviceDialog({Key? key, required this.removeDevice})
+      : super(key: key);
+
+  final Function() removeDevice;
+
+  @override
+  Widget build(BuildContext context) {
+    final model = context.watch<BluetoothDeviceModel>();
+    return SimpleDialog(
+      titlePadding: EdgeInsets.zero,
+      contentPadding: const EdgeInsets.only(left: 20, right: 20, bottom: 20),
+      title: YaruDialogTitle(
+        closeIconData: YaruIcons.window_close,
+        title: model.name,
+        titleWidget: Icon(
+            BluetoothDeviceTypes.getIconForAppearanceCode(model.appearance)),
+      ),
+      children: [
+        YaruRow(
+            enabled: true,
+            trailingWidget: model.connected
+                ? Text(context.l10n.connected)
+                : Text(context.l10n.disonnected),
+            actionWidget: Switch(
+                value: model.connected,
+                onChanged: (connectRequested) async {
+                  connectRequested
+                      ? await model.connect()
+                      : await model.disconnect();
+                })),
+        YaruRow(
+            enabled: true,
+            trailingWidget: Text(context.l10n.paired),
+            actionWidget: Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Text(model.paired ? context.l10n.yes : context.l10n.no),
+            )),
+        YaruRow(
+            enabled: true,
+            trailingWidget: Text(context.l10n.address),
+            actionWidget: Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Text(model.address),
+            )),
+        YaruRow(
+            enabled: true,
+            trailingWidget: Text(context.l10n.type),
+            actionWidget: Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Text(BluetoothDeviceTypes.map[model.appearance] ??
+                  context.l10n.unknown),
+            )),
+        Padding(
+          padding: const EdgeInsets.only(top: 16, bottom: 8, right: 8, left: 8),
+          child: SizedBox(
+            width: 300,
+            child: OutlinedButton(
+                onPressed: () {
+                  if (BluetoothDeviceTypes.isMouse(model.appearance)) {
+                    // TODO: get route name from model
+                    Navigator.of(context).pushNamed('routeName');
+                  }
+                },
+                child: Text(context.l10n.bluetoothOpenDeviceSettings)),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: SizedBox(
+            width: 300,
+            child: TextButton(
+                onPressed: () async {
+                  await model.disconnect();
+                  removeDevice();
+                  Navigator.of(context).pop();
+                },
+                child: Text(context.l10n.bluetoothRemoveDevice)),
+          ),
+        ),
+        if (model.errorMessage.isNotEmpty)
+          Text(
+            model.errorMessage,
+            style: TextStyle(color: Theme.of(context).errorColor),
+          )
+      ],
     );
   }
 }


### PR DESCRIPTION
- use ChangeNotifierProvider.value instead of statefulbuilder
- use YaruDialogTitle to get the close button and correct styling in the dialog

This also speeds up the process of displaying the connect/disconnect state for the switch about one second.

![Bildschirmfoto von 2022-02-07 11-42-16](https://user-images.githubusercontent.com/15329494/152772914-9a1e1484-f386-473b-92c7-c1b981bc9c65.png)
