### PR TITLE
Fix empty gpu error

### DIFF
--- a/lib/view/pages/info/info_model.dart
+++ b/lib/view/pages/info/info_model.dart
@@ -28,14 +28,14 @@ class InfoModel extends SafeChangeNotifier {
   final MemInfo _memInfo;
   final GnomeInfo _gnomeInfo;
 
-  String _gpuName = '';
+  String? _gpuName = '';
   int? _diskCapacity;
 
   Future<void> init() async {
     await _hostnameService.init();
 
     await GpuInfo.load().then((gpus) {
-      _gpuName = gpus.first.model;
+      _gpuName = gpus.isNotEmpty ? gpus.first.model : null;
     });
 
     await _uDisksClient.connect().then((value) {
@@ -61,7 +61,7 @@ class InfoModel extends SafeChangeNotifier {
   String get processorName => _cpus[0].model_name;
   int get processorCount => _cpus.length + 1;
   int get memory => _memInfo.mem_total_gb;
-  String get graphics => _gpuName;
+  String? get graphics => _gpuName;
   int? get diskCapacity => _diskCapacity;
 
   String get gnomeVersion => _gnomeInfo.version;

--- a/lib/view/pages/info/info_page.dart
+++ b/lib/view/pages/info/info_page.dart
@@ -98,7 +98,7 @@ class _InfoPageState extends State<InfoPage> {
           ),
           YaruSingleInfoRow(
             infoLabel: 'Graphics',
-            infoValue: model.graphics,
+            infoValue: model.graphics ?? 'No GPU info found',
           ),
           YaruSingleInfoRow(
             infoLabel: 'Disk Capacity',
@@ -142,7 +142,7 @@ class _InfoPageState extends State<InfoPage> {
                     model.processorName,
                     model.processorCount.toString(),
                     model.memory.toString(),
-                    model.graphics,
+                    model.graphics ?? 'No GPU info found',
                     model.diskCapacity != null
                         ? filesize(model.diskCapacity)
                         : '',


### PR DESCRIPTION
Add `No GPU info found` label when no gpu are in the list returned by `GpuInfo`.
This fix the exception throw when trying to access to the first element of the empty array.

@Feichtmeier Can you test this to see if it works as expected? I don't have a Flutter ready VM available.

Closes #297 